### PR TITLE
feat: add loading and error states to KpiCard

### DIFF
--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -290,7 +290,14 @@ const Dashboard: React.FC = () => {
         switch(component) {
             case 'KpiCard': {
                 const kpiConfig = config as KpiConfig;
-                return { title, value: kpiConfig.formatter(widgetData.kpiData[kpiConfig.valueKey]), description: kpiConfig.description };
+                const kpiData = widgetData.kpiData;
+                return {
+                    title,
+                    value: kpiData ? kpiConfig.formatter(kpiData[kpiConfig.valueKey]) : '',
+                    description: kpiConfig.description,
+                    isLoading: widget.isLoading,
+                    error: widget.error,
+                };
             }
             case 'LineChart':
             case 'BarChart':

--- a/components/charts/KpiCard.tsx
+++ b/components/charts/KpiCard.tsx
@@ -7,6 +7,8 @@ interface KpiCardProps {
   change?: string;
   changeType?: 'positive' | 'negative' | 'neutral';
   description?: string;
+  isLoading?: boolean;
+  error?: string;
 }
 
 // Sample data for demonstration
@@ -24,18 +26,49 @@ const KpiCard: React.FC<Partial<KpiCardProps>> = ({
   change = sampleData.change,
   changeType = sampleData.changeType,
   description = sampleData.description,
+  isLoading = false,
+  error,
 }) => {
   const changeColor = changeType === 'positive' ? 'text-green-500' : changeType === 'negative' ? 'text-red-500' : 'text-gray-500';
 
   return (
     <div className="bg-white p-6 rounded-lg shadow-lg">
-      <h3 className="text-sm font-medium text-gray-500 truncate">{title}</h3>
-      <p className="mt-1 text-3xl font-semibold text-gray-900">{value}</p>
-      {change && (
-        <p className="mt-2 text-sm text-gray-500">
-          <span className={`font-semibold ${changeColor}`}>{change}</span>
-          {description && <span className="ml-1">{description}</span>}
-        </p>
+      {isLoading ? (
+        <div className="flex items-center justify-center h-full">
+          <svg
+            className="animate-spin h-5 w-5 text-gray-500"
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+          >
+            <circle
+              className="opacity-25"
+              cx="12"
+              cy="12"
+              r="10"
+              stroke="currentColor"
+              strokeWidth="4"
+            ></circle>
+            <path
+              className="opacity-75"
+              fill="currentColor"
+              d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
+            ></path>
+          </svg>
+        </div>
+      ) : error ? (
+        <p className="text-sm text-red-500 text-center">{error}</p>
+      ) : (
+        <>
+          <h3 className="text-sm font-medium text-gray-500 truncate">{title}</h3>
+          <p className="mt-1 text-3xl font-semibold text-gray-900">{value}</p>
+          {change && (
+            <p className="mt-2 text-sm text-gray-500">
+              <span className={`font-semibold ${changeColor}`}>{change}</span>
+              {description && <span className="ml-1">{description}</span>}
+            </p>
+          )}
+        </>
       )}
     </div>
   );

--- a/components/dashboardConfig.ts
+++ b/components/dashboardConfig.ts
@@ -25,6 +25,7 @@ export const DASHBOARD_CONFIG: DashboardConfig = {
             component: 'KpiCard',
             gridClass: 'col-span-1 md:col-span-2 lg:col-span-3',
             title: 'Vendas Totais',
+            isLoading: false,
             config: {
                 valueKey: 'totalVendas',
                 description: 'para a seleção atual',
@@ -36,6 +37,7 @@ export const DASHBOARD_CONFIG: DashboardConfig = {
             component: 'KpiCard',
             gridClass: 'col-span-1 md:col-span-2 lg:col-span-3',
             title: 'Lucro Total',
+            isLoading: false,
             config: {
                 valueKey: 'totalLucro',
                 description: 'para a seleção atual',
@@ -47,6 +49,7 @@ export const DASHBOARD_CONFIG: DashboardConfig = {
             component: 'KpiCard',
             gridClass: 'col-span-1 md:col-span-2 lg:col-span-3',
             title: 'Total de Clientes',
+            isLoading: false,
             config: {
                 valueKey: 'totalClientes',
                 description: 'na seleção atual',
@@ -58,6 +61,7 @@ export const DASHBOARD_CONFIG: DashboardConfig = {
             component: 'KpiCard',
             gridClass: 'col-span-1 md:col-span-2 lg:col-span-3',
             title: 'Ticket Médio',
+            isLoading: false,
             config: {
                 valueKey: 'ticketMedio',
                 description: 'por cliente na seleção',

--- a/types.ts
+++ b/types.ts
@@ -225,6 +225,8 @@ export interface DashboardWidget {
     gridClass: string;
     title?: string;
     config: WidgetConfig;
+    isLoading?: boolean;
+    error?: string;
 }
 
 export interface DashboardConfig {


### PR DESCRIPTION
## Summary
- add `isLoading` and `error` props to `KpiCard`
- pass loading state through dashboard widget config

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689893c802c083319fa9e31ff9c1aaff