### PR TITLE
feat: add optional titles to icons

### DIFF
--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -387,7 +387,7 @@ const Dashboard: React.FC = () => {
                 const f = filterOptions[filterKey];
                 return <MultiSelectFilter key={filterKey} placeholder={`Filtrar por ${f.label}...`} options={f.options} selected={f.selected} onChange={f.setter} />
             })}
-             {hasFilters && <button onClick={clearFilters} className="p-2 text-gray-500 hover:text-red-600 hover:bg-red-100 rounded-full transition-colors" title="Limpar Filtros"><XIcon className="w-5 h-5"/></button>}
+            {hasFilters && <button onClick={clearFilters} className="p-2 text-gray-500 hover:text-red-600 hover:bg-red-100 rounded-full transition-colors" title="Limpar Filtros"><XIcon title="Limpar Filtros" className="w-5 h-5"/></button>}
         </div>
       </div>
       

--- a/components/DataTable.tsx
+++ b/components/DataTable.tsx
@@ -260,12 +260,12 @@ export default function DataTable<T extends DataItem>({
             className="px-3 py-2 bg-white text-gray-900 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-[#00A3E0] focus:border-[#00A3E0] sm:text-sm placeholder-gray-400 w-full sm:w-64 order-2 sm:order-1"
             aria-label="Buscar na tabela"
           />
-           <button
+          <button
             onClick={handleClearAllFilters}
             className="flex items-center bg-gray-200 hover:bg-gray-300 text-gray-700 font-semibold py-2 px-4 rounded-md shadow-md transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-400 w-full sm:w-auto justify-center order-2 sm:order-1 whitespace-nowrap"
             title="Limpar todos os filtros e ordenação"
           >
-            <FilterSlashIcon className="w-5 h-5 mr-2" />
+            <FilterSlashIcon title="Limpar filtros" className="w-5 h-5 mr-2" />
             Limpar Todos os Filtros
           </button>
           {canPerformWriteActions && (
@@ -273,7 +273,7 @@ export default function DataTable<T extends DataItem>({
               onClick={onAddItem}
               className="flex items-center bg-[#00A3E0] hover:bg-[#0082B8] text-white font-semibold py-2 px-4 rounded-md shadow-md transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[#00A3E0] w-full sm:w-auto justify-center order-1 sm:order-3"
             >
-              <PlusIcon className="w-5 h-5 mr-2" />
+              <PlusIcon title="Adicionar novo" className="w-5 h-5 mr-2" />
               Adicionar Novo
             </button>
           )}
@@ -309,7 +309,7 @@ export default function DataTable<T extends DataItem>({
                       aria-haspopup="true"
                       aria-expanded={activeFilterDropdown === col.accessor}
                     >
-                      <FunnelIcon className="w-4 h-4" />
+                      <FunnelIcon title={`Filtrar ${col.header}`} className="w-4 h-4" />
                     </button>
                   </div>
                   {activeFilterDropdown === col.accessor && (
@@ -321,7 +321,7 @@ export default function DataTable<T extends DataItem>({
                       <div className="flex justify-between items-center mb-2">
                          <h4 className="text-sm font-semibold text-gray-700">Filtrar {col.header}</h4>
                          <button onClick={closeFilterDropdown} className="p-1 text-gray-400 hover:text-gray-600">
-                            <XIcon className="w-4 h-4" />
+                            <XIcon title="Fechar" className="w-4 h-4" />
                          </button>
                       </div>
                      
@@ -411,7 +411,7 @@ export default function DataTable<T extends DataItem>({
                           className="text-[#00A3E0] hover:text-[#0082B8] transition-colors duration-150 p-1 rounded hover:bg-[#E0F7FF]"
                           title="Editar"
                         >
-                          <PencilIcon className="w-5 h-5" />
+                          <PencilIcon title="Editar" className="w-5 h-5" />
                         </button>
                       )}
                       {userRole === 'admin' && (
@@ -420,7 +420,7 @@ export default function DataTable<T extends DataItem>({
                           className="text-[#D9262E] hover:text-[#B01F25] transition-colors duration-150 p-1 rounded hover:bg-[#FEEBEE]"
                           title="Excluir"
                         >
-                          <TrashIcon className="w-5 h-5" />
+                          <TrashIcon title="Excluir" className="w-5 h-5" />
                         </button>
                       )}
                     </td>

--- a/components/Modal.tsx
+++ b/components/Modal.tsx
@@ -142,7 +142,7 @@ const Modal: React.FC<ModalProps> = ({
         <div className="flex justify-between items-center mb-4">
           <h2 id="modal-title" className="text-2xl font-semibold text-gray-800">{title}</h2>
           <button onClick={onClose} className="text-gray-500 hover:text-gray-700" aria-label="Fechar modal">
-            <XIcon className="w-6 h-6" />
+            <XIcon title="Fechar" className="w-6 h-6" />
           </button>
         </div>
         {bodyContent ? (

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -35,7 +35,7 @@ const Sidebar: React.FC<SidebarProps> = ({ menuItems, activeTabId, onSelectTab, 
             role="menuitem"
             aria-current={activeTabId === item.id ? 'page' : undefined}
           >
-            <item.icon className="w-5 h-5 flex-shrink-0" />
+            <item.icon title={item.label} className="w-5 h-5 flex-shrink-0" />
             {isOpen && <span className="truncate">{item.label}</span>}
           </button>
         ))}

--- a/components/TopBar.tsx
+++ b/components/TopBar.tsx
@@ -48,7 +48,7 @@ const TopBar: React.FC<TopBarProps> = ({
           className="p-1 rounded-md hover:bg-[#003C73] focus:outline-none focus:ring-2 focus:ring-[#00A3E0]"
           aria-label="Alternar menu lateral"
         >
-          <MenuIcon className="w-7 h-7 text-[#00A3E0]" />
+          <MenuIcon title="Abrir menu" className="w-7 h-7 text-[#00A3E0]" />
         </button>
         <h1 className="text-xl font-semibold truncate" title="StoneX Business Rules Manager">
           StoneX BRules
@@ -65,7 +65,7 @@ const TopBar: React.FC<TopBarProps> = ({
             aria-expanded={isUserDropdownOpen}
             aria-controls="user-menu"
           >
-            <UserCircleIcon className="w-7 h-7" />
+            <UserCircleIcon title="Usuário" className="w-7 h-7" />
             <span className="hidden sm:inline text-sm font-medium">{userName}</span>
           </button>
 
@@ -84,7 +84,7 @@ const TopBar: React.FC<TopBarProps> = ({
                   role="menuitem"
                   id="user-menu-item-0"
                 >
-                  <IdentificationIcon className="w-5 h-5 mr-3 text-gray-500" />
+                  <IdentificationIcon title="Perfil" className="w-5 h-5 mr-3 text-gray-500" />
                   Perfil
                 </button>
                 <button
@@ -93,7 +93,7 @@ const TopBar: React.FC<TopBarProps> = ({
                   role="menuitem"
                   id="user-menu-item-1"
                 >
-                  <ArrowLeftOnRectangleIcon className="w-5 h-5 mr-3 text-gray-500" />
+                  <ArrowLeftOnRectangleIcon title="Logout" className="w-5 h-5 mr-3 text-gray-500" />
                   Logout
                 </button>
               </div>

--- a/components/charts/ScatterChart.tsx
+++ b/components/charts/ScatterChart.tsx
@@ -119,7 +119,7 @@ const ScatterChart: React.FC<ScatterChartProps> = ({ data, title, config }) => {
             {playAxis && (
                 <div className="flex items-center justify-center gap-4 mb-4 p-2 bg-gray-50 rounded-lg">
                     <button onClick={() => isPlaying ? stopPlaying() : startPlaying()} className="p-2 rounded-full hover:bg-gray-200 transition-colors">
-                        {isPlaying ? <PauseIcon className="w-6 h-6 text-gray-700" /> : <PlayIcon className="w-6 h-6 text-gray-700" />}
+                        {isPlaying ? <PauseIcon title="Pausar" className="w-6 h-6 text-gray-700" /> : <PlayIcon title="Reproduzir" className="w-6 h-6 text-gray-700" />}
                     </button>
                     <label htmlFor="play-axis-slider" className="text-sm font-medium text-gray-600 whitespace-nowrap">{playAxis.label}: <span className="font-bold text-gray-800">{currentPlayAxisValue}</span></label>
                     <input

--- a/components/icons/ArrowLeftOnRectangleIcon.tsx
+++ b/components/icons/ArrowLeftOnRectangleIcon.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 
 // Heroicons: arrow-left-on-rectangle (for Logout)
-const ArrowLeftOnRectangleIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+const ArrowLeftOnRectangleIcon: React.FC<React.SVGProps<SVGSVGElement> & { title?: string }> = ({ title, ...props }) => (
   <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
+    {title ? <title>{title}</title> : null}
     <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 9V5.25A2.25 2.25 0 0 0 13.5 3h-6a2.25 2.25 0 0 0-2.25 2.25v13.5A2.25 2.25 0 0 0 7.5 21h6a2.25 2.25 0 0 0 2.25-2.25V15m-3 0-3-3m0 0 3-3m-3 3H15.75" />
   </svg>
 );

--- a/components/icons/ArrowRightOnRectangleIcon.tsx
+++ b/components/icons/ArrowRightOnRectangleIcon.tsx
@@ -2,8 +2,9 @@
 import React from 'react';
 
 // This is often used for "Login", but can also represent "Exit" if arrow points right
-const ArrowRightOnRectangleIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+const ArrowRightOnRectangleIcon: React.FC<React.SVGProps<SVGSVGElement> & { title?: string }> = ({ title, ...props }) => (
   <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
+    {title ? <title>{title}</title> : null}
     <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 9V5.25A2.25 2.25 0 0013.5 3h-6a2.25 2.25 0 00-2.25 2.25v13.5A2.25 2.25 0 007.5 21h6a2.25 2.25 0 002.25-2.25V15M12 9l-3 3m0 0l3 3m-3-3h12.75" />
   </svg>
 );

--- a/components/icons/ChartPieIcon.tsx
+++ b/components/icons/ChartPieIcon.tsx
@@ -1,8 +1,9 @@
 
 import React from 'react';
 
-const ChartPieIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+const ChartPieIcon: React.FC<React.SVGProps<SVGSVGElement> & { title?: string }> = ({ title, ...props }) => (
   <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
+    {title ? <title>{title}</title> : null}
     <path strokeLinecap="round" strokeLinejoin="round" d="M10.5 6a7.5 7.5 0 107.5 7.5h-7.5V6z" />
     <path strokeLinecap="round" strokeLinejoin="round" d="M13.5 10.5H21A7.5 7.5 0 0013.5 3v7.5z" />
   </svg>

--- a/components/icons/CheckIcon.tsx
+++ b/components/icons/CheckIcon.tsx
@@ -1,8 +1,9 @@
 
 import React from 'react';
 
-const CheckIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+const CheckIcon: React.FC<React.SVGProps<SVGSVGElement> & { title?: string }> = ({ title, ...props }) => (
   <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
+    {title ? <title>{title}</title> : null}
     <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 12.75l6 6 9-13.5" />
   </svg>
 );

--- a/components/icons/FilterSlashIcon.tsx
+++ b/components/icons/FilterSlashIcon.tsx
@@ -1,8 +1,9 @@
 
 import React from 'react';
 
-const FilterSlashIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+const FilterSlashIcon: React.FC<React.SVGProps<SVGSVGElement> & { title?: string }> = ({ title, ...props }) => (
   <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
+    {title ? <title>{title}</title> : null}
     <path strokeLinecap="round" strokeLinejoin="round" d="M12 3c2.755 0 5.455.232 8.083.678.533.09.917.556.917 1.096v1.044a2.25 2.25 0 01-.659 1.591l-5.432 5.432a2.25 2.25 0 00-.659 1.591v2.927a2.25 2.25 0 01-1.044 1.887l-2.25 1.125a2.25 2.25 0 01-2.706 0l-2.25-1.125a2.25 2.25 0 01-1.044-1.887v-2.927a2.25 2.25 0 00-.659-1.591L2.659 6.818A2.25 2.25 0 012 5.227V4.182c0-.54.384-1.006.917-1.096A48.32 48.32 0 0112 3zM3 3l18 18" />
   </svg>
 );

--- a/components/icons/FunnelIcon.tsx
+++ b/components/icons/FunnelIcon.tsx
@@ -1,8 +1,9 @@
 
 import React from 'react';
 
-const FunnelIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+const FunnelIcon: React.FC<React.SVGProps<SVGSVGElement> & { title?: string }> = ({ title, ...props }) => (
   <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
+    {title ? <title>{title}</title> : null}
     <path strokeLinecap="round" strokeLinejoin="round" d="M12 3c2.755 0 5.455.232 8.083.678.533.09.917.556.917 1.096v1.044a2.25 2.25 0 01-.659 1.591l-5.432 5.432a2.25 2.25 0 00-.659 1.591v2.927a2.25 2.25 0 01-1.044 1.887l-2.25 1.125a2.25 2.25 0 01-2.706 0l-2.25-1.125a2.25 2.25 0 01-1.044-1.887v-2.927a2.25 2.25 0 00-.659-1.591L2.659 6.818A2.25 2.25 0 012 5.227V4.182c0-.54.384-1.006.917-1.096A48.32 48.32 0 0112 3z" />
   </svg>
 );

--- a/components/icons/IdentificationIcon.tsx
+++ b/components/icons/IdentificationIcon.tsx
@@ -1,8 +1,9 @@
 
 import React from 'react';
 
-const IdentificationIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+const IdentificationIcon: React.FC<React.SVGProps<SVGSVGElement> & { title?: string }> = ({ title, ...props }) => (
   <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
+    {title ? <title>{title}</title> : null}
     <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 6a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0zM4.501 20.118a7.5 7.5 0 0114.998 0A17.933 17.933 0 0112 21.75c-2.676 0-5.216-.584-7.499-1.632z" />
     <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0zm-3 9a7.5 7.5 0 007.5-7.5h-15a7.5 7.5 0 007.5 7.5z" />
     <path strokeLinecap="round" strokeLinejoin="round" d="M3.375 19.5h17.25" />

--- a/components/icons/MenuIcon.tsx
+++ b/components/icons/MenuIcon.tsx
@@ -1,8 +1,9 @@
 
 import React from 'react';
 
-const MenuIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+const MenuIcon: React.FC<React.SVGProps<SVGSVGElement> & { title?: string }> = ({ title, ...props }) => (
   <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
+    {title ? <title>{title}</title> : null}
     <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
   </svg>
 );

--- a/components/icons/PauseIcon.tsx
+++ b/components/icons/PauseIcon.tsx
@@ -1,8 +1,9 @@
 
 import React from 'react';
 
-const PauseIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+const PauseIcon: React.FC<React.SVGProps<SVGSVGElement> & { title?: string }> = ({ title, ...props }) => (
   <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
+    {title ? <title>{title}</title> : null}
     <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 5.25v13.5m-7.5-13.5v13.5" />
   </svg>
 );

--- a/components/icons/PencilIcon.tsx
+++ b/components/icons/PencilIcon.tsx
@@ -1,8 +1,9 @@
 
 import React from 'react';
 
-const PencilIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+const PencilIcon: React.FC<React.SVGProps<SVGSVGElement> & { title?: string }> = ({ title, ...props }) => (
   <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
+    {title ? <title>{title}</title> : null}
     <path strokeLinecap="round" strokeLinejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0115.75 21H5.25A2.25 2.25 0 013 18.75V8.25A2.25 2.25 0 015.25 6H10" />
   </svg>
 );

--- a/components/icons/PlayIcon.tsx
+++ b/components/icons/PlayIcon.tsx
@@ -1,8 +1,9 @@
 
 import React from 'react';
 
-const PlayIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+const PlayIcon: React.FC<React.SVGProps<SVGSVGElement> & { title?: string }> = ({ title, ...props }) => (
   <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
+    {title ? <title>{title}</title> : null}
     <path strokeLinecap="round" strokeLinejoin="round" d="M5.25 5.653c0-.856.917-1.398 1.667-.986l11.54 6.348a1.125 1.125 0 010 1.971l-11.54 6.347a1.125 1.125 0 01-1.667-.985V5.653z" />
   </svg>
 );

--- a/components/icons/PlusIcon.tsx
+++ b/components/icons/PlusIcon.tsx
@@ -1,8 +1,9 @@
 
 import React from 'react';
 
-const PlusIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+const PlusIcon: React.FC<React.SVGProps<SVGSVGElement> & { title?: string }> = ({ title, ...props }) => (
   <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
+    {title ? <title>{title}</title> : null}
     <path strokeLinecap="round" strokeLinejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
   </svg>
 );

--- a/components/icons/TableIcon.tsx
+++ b/components/icons/TableIcon.tsx
@@ -1,8 +1,9 @@
 
 import React from 'react';
 
-const TableIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+const TableIcon: React.FC<React.SVGProps<SVGSVGElement> & { title?: string }> = ({ title, ...props }) => (
   <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
+    {title ? <title>{title}</title> : null}
     <path strokeLinecap="round" strokeLinejoin="round" d="M9 4.5v15m6-15v15m-10.875 0h15.75c.621 0 1.125-.504 1.125-1.125V5.625c0-.621-.504-1.125-1.125-1.125H4.125C3.504 4.5 3 5.004 3 5.625v12.75c0 .621.504 1.125 1.125 1.125z" />
   </svg>
 );

--- a/components/icons/TrashIcon.tsx
+++ b/components/icons/TrashIcon.tsx
@@ -1,8 +1,9 @@
 
 import React from 'react';
 
-const TrashIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+const TrashIcon: React.FC<React.SVGProps<SVGSVGElement> & { title?: string }> = ({ title, ...props }) => (
   <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
+    {title ? <title>{title}</title> : null}
     <path strokeLinecap="round" strokeLinejoin="round" d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12.56 0c1.153 0 2.24.02 3.22.055m9.34 0c-.091.026-.18.052-.27.077m-13.086 0c.091.026.18.052.27.077M4.772 5.79L4.772 4.74a2.25 2.25 0 012.25-2.25h8.956a2.25 2.25 0 012.25 2.25v1.05M4.772 5.79l-.238.192A2.25 2.25 0 003 7.705V19.255a2.25 2.25 0 002.25 2.25h13.5A2.25 2.25 0 0021 19.255V7.705a2.25 2.25 0 00-1.534-2.103l-.238-.192" />
   </svg>
 );

--- a/components/icons/UserCircleIcon.tsx
+++ b/components/icons/UserCircleIcon.tsx
@@ -1,8 +1,9 @@
 
 import React from 'react';
 
-const UserCircleIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+const UserCircleIcon: React.FC<React.SVGProps<SVGSVGElement> & { title?: string }> = ({ title, ...props }) => (
   <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
+    {title ? <title>{title}</title> : null}
     <path strokeLinecap="round" strokeLinejoin="round" d="M17.982 18.725A7.488 7.488 0 0012 15.75a7.488 7.488 0 00-5.982 2.975m11.963 0a9 9 0 10-11.963 0m11.963 0A8.966 8.966 0 0112 21a8.966 8.966 0 01-5.982-2.275M15 9.75a3 3 0 11-6 0 3 3 0 016 0z" />
   </svg>
 );

--- a/components/icons/XIcon.tsx
+++ b/components/icons/XIcon.tsx
@@ -1,8 +1,9 @@
 
 import React from 'react';
 
-const XIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+const XIcon: React.FC<React.SVGProps<SVGSVGElement> & { title?: string }> = ({ title, ...props }) => (
   <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
+    {title ? <title>{title}</title> : null}
     <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
   </svg>
 );


### PR DESCRIPTION
## Summary
- allow icon components to accept optional `title` prop and render `<title>` for accessibility
- add descriptive titles to icon usages across the app

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689894094ee48331b32e3bcb65365aea