### PR TITLE
feat: add sortable list utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,42 @@ This contains everything you need to run your app locally.
 2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
 3. Run the app:
    `npm run dev`
+
+## Drag-and-drop utilities
+
+`utils/dnd.ts` exposes a reusable `SortableList` component and type-safe
+hooks for reordering collections.
+
+```tsx
+import { SortableList, useSortableList, useSortableItem } from './utils/dnd';
+
+interface MenuItem { id: string; label: string }
+
+export function Menu({ items }: { items: MenuItem[] }) {
+  return (
+    <SortableList items={items}>
+      <MenuItems />
+    </SortableList>
+  );
+}
+
+function MenuItems() {
+  const { items } = useSortableList<MenuItem>();
+  return (
+    <ul>
+      {items.map((item) => {
+        const { attributes, listeners, setNodeRef } = useSortableItem(item.id);
+        return (
+          <li key={item.id} ref={setNodeRef} {...attributes} {...listeners}>
+            {item.label}
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+```
+
+Wrap your rows or menu items in `SortableList` and access the ordered
+values via `useSortableList`. Apply the props from `useSortableItem` to
+each element to make it draggable.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "gerenciador-de-dados-financeiros",
       "version": "0.0.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
         "focus-trap-react": "^11.0.4",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -476,6 +478,59 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -3640,6 +3695,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/type-detect": {
       "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -10,12 +10,14 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
     "focus-trap-react": "^11.0.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-simple-maps": "^3.0.0",
     "react-grid-layout": "^1.3.4",
     "react-resizable": "^3.0.5",
+    "react-simple-maps": "^3.0.0",
     "recharts": "^2.12.7"
   },
   "devDependencies": {

--- a/utils/dnd.ts
+++ b/utils/dnd.ts
@@ -1,0 +1,59 @@
+import { DndContext, PointerSensor, closestCenter, useSensor, useSensors, DragEndEvent } from '@dnd-kit/core';
+import { SortableContext, verticalListSortingStrategy, useSortable, arrayMove } from '@dnd-kit/sortable';
+import React, { createContext, useContext, useState } from 'react';
+
+interface ItemWithId {
+  id: string;
+}
+
+interface SortableListContextValue<T extends ItemWithId> {
+  items: T[];
+  setItems: React.Dispatch<React.SetStateAction<T[]>>;
+}
+
+const SortableListContext = createContext<SortableListContextValue<any> | undefined>(undefined);
+
+export function SortableList<T extends ItemWithId>({
+  items: initialItems,
+  children,
+}: {
+  items: T[];
+  children: React.ReactNode;
+}) {
+  const [items, setItems] = useState<T[]>(initialItems);
+  const sensors = useSensors(useSensor(PointerSensor));
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (over && active.id !== over.id) {
+      setItems((items) => {
+        const oldIndex = items.findIndex((item) => item.id === active.id);
+        const newIndex = items.findIndex((item) => item.id === over.id);
+        return arrayMove(items, oldIndex, newIndex);
+      });
+    }
+  };
+
+  return (
+    <SortableListContext.Provider value={{ items, setItems }}>
+      <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+        <SortableContext items={items.map((item) => item.id)} strategy={verticalListSortingStrategy}>
+          {children}
+        </SortableContext>
+      </DndContext>
+    </SortableListContext.Provider>
+  );
+}
+
+export function useSortableList<T extends ItemWithId>() {
+  const context = useContext(SortableListContext);
+  if (!context) {
+    throw new Error('useSortableList must be used within a SortableList');
+  }
+  return context as SortableListContextValue<T>;
+}
+
+export function useSortableItem(id: string) {
+  return useSortable({ id });
+}
+


### PR DESCRIPTION
## Summary
- add @dnd-kit/core and @dnd-kit/sortable dependencies
- provide reusable SortableList component with hooks for list reordering
- document drag-and-drop utility usage

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898aaee1c608331b0f1ed3d4ee85903