### PR TITLE
feat: add editable hook and context provider

### DIFF
--- a/context/EditContext.tsx
+++ b/context/EditContext.tsx
@@ -1,0 +1,34 @@
+import { createContext, ReactNode, useContext } from 'react';
+import useEditable from '@/hooks/useEditable';
+
+interface EditContextValue {
+  isEditing: boolean;
+  startEdit: () => void;
+  stopEdit: () => void;
+}
+
+const EditContext = createContext<EditContextValue | undefined>(undefined);
+
+interface EditProviderProps {
+  children: ReactNode;
+}
+
+export function EditProvider({ children }: EditProviderProps) {
+  const editable = useEditable();
+
+  return (
+    <EditContext.Provider value={editable}>
+      {children}
+    </EditContext.Provider>
+  );
+}
+
+export function useEdit() {
+  const context = useContext(EditContext);
+  if (context === undefined) {
+    throw new Error('useEdit must be used within an EditProvider');
+  }
+  return context;
+}
+
+export default EditContext;

--- a/context/README.md
+++ b/context/README.md
@@ -1,0 +1,32 @@
+# Edit Context
+
+Provides shared editing state across components.
+
+## `useEditable`
+
+A hook that manages a boolean `isEditing` flag and exposes `startEdit` and `stopEdit` helpers.
+
+```tsx
+const { isEditing, startEdit, stopEdit } = useEditable();
+```
+
+## `EditProvider`
+
+Wrap components with `EditProvider` to share editing state via context.
+
+```tsx
+import { EditProvider, useEdit } from '@/context/EditContext';
+
+function SomeComponent() {
+  const { isEditing, startEdit, stopEdit } = useEdit();
+  // ...
+}
+
+function App() {
+  return (
+    <EditProvider>
+      <SomeComponent />
+    </EditProvider>
+  );
+}
+```

--- a/hooks/useEditable.ts
+++ b/hooks/useEditable.ts
@@ -1,0 +1,16 @@
+import { useState } from 'react';
+
+interface UseEditable {
+  isEditing: boolean;
+  startEdit: () => void;
+  stopEdit: () => void;
+}
+
+export default function useEditable(initial: boolean = false): UseEditable {
+  const [isEditing, setIsEditing] = useState(initial);
+
+  const startEdit = () => setIsEditing(true);
+  const stopEdit = () => setIsEditing(false);
+
+  return { isEditing, startEdit, stopEdit };
+}


### PR DESCRIPTION
## Summary
- add `useEditable` hook for managing edit mode
- introduce `EditProvider` and `useEdit` for shared editing state
- document hook and provider usage

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898aae6a8808331b5c89f5665c07460