### PR TITLE
feat: enable dashboard widget editing and palette

### DIFF
--- a/components/WidgetPalette.tsx
+++ b/components/WidgetPalette.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { ChartComponentType, DashboardWidget, WidgetConfig } from '../types.ts';
+
+interface PaletteItem {
+  type: ChartComponentType;
+  label: string;
+  defaultConfig: WidgetConfig;
+}
+
+const paletteItems: PaletteItem[] = [
+  {
+    type: 'KpiCard',
+    label: 'KPI',
+    defaultConfig: {
+      valueKey: 'totalVendas',
+      description: '',
+      formatter: (v: number) => v.toString(),
+    } as any,
+  },
+  {
+    type: 'BarChart',
+    label: 'Bar',
+    defaultConfig: {
+      sourceDataKey: 'detailedData',
+      chartType: 'Bar',
+      category: { dataKey: 'mes' },
+      value: { dataKey: 'vendas', aggregation: 'SUM' },
+    } as any,
+  },
+];
+
+const WidgetPalette: React.FC = () => {
+  return (
+    <div className="flex gap-2">
+      {paletteItems.map((item) => (
+        <div
+          key={item.type}
+          draggable
+          onDragStart={(e) => e.dataTransfer.setData('widgetType', item.type)}
+          className="p-2 bg-gray-100 border rounded cursor-move select-none"
+        >
+          {item.label}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default WidgetPalette;
+
+export const createWidgetFromType = (type: ChartComponentType, id: string): DashboardWidget => {
+  const item = paletteItems.find((i) => i.type === type);
+  return {
+    id,
+    component: type,
+    gridClass: 'col-span-1',
+    title: item?.label || type,
+    config: item?.defaultConfig || ({} as WidgetConfig),
+  };
+};

--- a/tests/dashboardLayout.test.ts
+++ b/tests/dashboardLayout.test.ts
@@ -1,32 +1,42 @@
 import { test, expect, beforeEach } from 'vitest';
-import { applyLayoutToWidgets } from '../components/Dashboard.tsx';
+import { applyLayoutToWidgets, addWidget } from '../components/Dashboard.tsx';
 import { saveDashboardConfig, getDashboardConfig } from '../services/dashboardData.ts';
-import { DashboardConfig } from '../types.ts';
+import { DashboardConfig, DashboardWidget } from '../types.ts';
 
 beforeEach(() => {
   localStorage.clear();
 });
 
-test('applyLayoutToWidgets updates widget layout', () => {
-  const config: DashboardConfig = {
-    filters: [],
-    widgets: [
-      { id: 'w1', component: 'KpiCard', gridClass: '', config: {} as any }
-    ]
-  };
-  const layout = [{ i: 'w1', x: 2, y: 3, w: 4, h: 5 }];
-  const updated = applyLayoutToWidgets(config, layout);
-  expect(updated.widgets[0].layout).toEqual({ x: 2, y: 3, w: 4, h: 5 });
-});
-
-test('saveDashboardConfig persists config', async () => {
+test('drag updates widget position', () => {
   const config: DashboardConfig = {
     filters: [],
     widgets: [
       { id: 'w1', component: 'KpiCard', gridClass: '', config: {} as any, layout: { x: 0, y: 0, w: 1, h: 1 } }
     ]
   };
-  await saveDashboardConfig(config);
+  const layout = [{ i: 'w1', x: 5, y: 6, w: 1, h: 1 }];
+  const updated = applyLayoutToWidgets(config, layout);
+  expect(updated.widgets[0].layout).toEqual({ x: 5, y: 6, w: 1, h: 1 });
+});
+
+test('resize updates widget size', () => {
+  const config: DashboardConfig = {
+    filters: [],
+    widgets: [
+      { id: 'w1', component: 'KpiCard', gridClass: '', config: {} as any, layout: { x: 0, y: 0, w: 1, h: 1 } }
+    ]
+  };
+  const layout = [{ i: 'w1', x: 0, y: 0, w: 3, h: 4 }];
+  const updated = applyLayoutToWidgets(config, layout);
+  expect(updated.widgets[0].layout).toEqual({ x: 0, y: 0, w: 3, h: 4 });
+});
+
+test('addWidget appends widget to config', async () => {
+  const config: DashboardConfig = { filters: [], widgets: [] };
+  const widget: DashboardWidget = { id: 'new', component: 'KpiCard', gridClass: '', config: {} as any };
+  const updated = addWidget(config, widget);
+  expect(updated.widgets).toHaveLength(1);
+  await saveDashboardConfig(updated);
   const loaded = await getDashboardConfig();
-  expect(loaded.widgets[0].layout).toEqual({ x: 0, y: 0, w: 1, h: 1 });
+  expect(loaded.widgets).toHaveLength(1);
 });


### PR DESCRIPTION
## Summary
- add draggable widget palette for grid drops
- allow widget title editing and persist to config
- show dashed grid with ghost placeholders when editing
- test drag, resize and widget addition helpers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898ac3aba888331bf271e29586f9beb