### PR TITLE
feat: make sidebar customizable

### DIFF
--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -1,6 +1,7 @@
 
-import React, { useRef } from 'react';
-import { MenuItem, DataItem } from '../types.ts'; 
+import React, { useRef, useState, useEffect } from 'react';
+import { MenuItem, DataItem } from '../types.ts';
+import SortableList from './SortableList.tsx';
 // MenuIcon is no longer needed here as it's moved to TopBar
 
 interface SidebarProps {
@@ -13,6 +14,34 @@ interface SidebarProps {
 
 const Sidebar: React.FC<SidebarProps> = ({ menuItems, activeTabId, onSelectTab, isOpen }) => {
   const itemRefs = useRef<(HTMLButtonElement | null)[]>([]);
+  const [items, setItems] = useState<MenuItem<DataItem>[]>(() => {
+    const stored = localStorage.getItem('sidebar-menu');
+    if (stored) {
+      try {
+        const parsed: { id: string; label: string; hidden?: boolean }[] = JSON.parse(stored);
+        const map = new Map(parsed.map((p, i) => [p.id, { ...p, order: i }]));
+        const ordered = parsed
+          .map((p) => {
+            const base = menuItems.find((mi) => mi.id === p.id);
+            return base ? { ...base, label: p.label, hidden: p.hidden } : undefined;
+          })
+          .filter(Boolean) as MenuItem<DataItem>[];
+        const missing = menuItems.filter((mi) => !map.has(mi.id));
+        return [...ordered, ...missing];
+      } catch {
+        return menuItems;
+      }
+    }
+    return menuItems;
+  });
+  const [isEditing, setIsEditing] = useState(false);
+
+  useEffect(() => {
+    const meta = items.map(({ id, label, hidden }) => ({ id, label, hidden }));
+    localStorage.setItem('sidebar-menu', JSON.stringify(meta));
+  }, [items]);
+
+  const visibleItems = items.filter((item) => !item.hidden);
 
   const handleKeyDown = (
     event: React.KeyboardEvent<HTMLButtonElement>,
@@ -22,13 +51,13 @@ const Sidebar: React.FC<SidebarProps> = ({ menuItems, activeTabId, onSelectTab, 
     switch (event.key) {
       case 'ArrowDown': {
         event.preventDefault();
-        const nextIndex = (index + 1) % menuItems.length;
+        const nextIndex = (index + 1) % visibleItems.length;
         itemRefs.current[nextIndex]?.focus();
         break;
       }
       case 'ArrowUp': {
         event.preventDefault();
-        const prevIndex = (index - 1 + menuItems.length) % menuItems.length;
+        const prevIndex = (index - 1 + visibleItems.length) % visibleItems.length;
         itemRefs.current[prevIndex]?.focus();
         break;
       }
@@ -43,36 +72,78 @@ const Sidebar: React.FC<SidebarProps> = ({ menuItems, activeTabId, onSelectTab, 
     }
   };
 
+  const handleReorder = (newItems: MenuItem<DataItem>[]) => {
+    setItems(newItems);
+  };
+
+  const handleLabelChange = (id: string, label: string) => {
+    setItems((prev) => prev.map((it) => (it.id === id ? { ...it, label } : it)));
+  };
+
+  const handleToggleHidden = (id: string) => {
+    setItems((prev) => prev.map((it) => (it.id === id ? { ...it, hidden: !it.hidden } : it)));
+  };
+
+  const listItems = isEditing ? items : visibleItems;
+
   return (
     <div
-      className={`bg-[#002D5A] text-white fixed top-16 left-0 bottom-0 flex flex-col transition-all duration-300 ease-in-out ${isOpen ? 'w-64 p-4' : 'w-20 p-4'} z-30`} // Added z-30
+      className={`bg-[#002D5A] text-white fixed top-16 left-0 bottom-0 flex flex-col transition-all duration-300 ease-in-out ${isOpen ? 'w-64 p-4' : 'w-20 p-4'} z-30`}
       aria-label="Menu de navegação principal"
-      style={{ height: 'calc(100vh - 4rem)' }} // Ensure it doesn't overlap TopBar
+      style={{ height: 'calc(100vh - 4rem)' }}
     >
-      {/* Header section (toggle button and title) is removed and moved to TopBar */}
-      {/* Optional: Add a small padding or border if the first item is too close to the top after removing header */}
-      <div className={`${isOpen && menuItems.length > 0 ? 'pt-4' : ''}`}> 
+      <div className="mb-2">
+        <button
+          onClick={() => setIsEditing((p) => !p)}
+          className="px-2 py-1 rounded bg-[#003C73] text-sm"
+        >
+          {isEditing ? 'Done' : 'Edit'}
+        </button>
       </div>
       <nav className="space-y-2 flex-grow overflow-y-auto">
-        {menuItems.map((item, index) => (
-          <button
-            key={item.id}
-            onClick={() => onSelectTab(item.id)}
-            tabIndex={0}
-            onKeyDown={(e) => handleKeyDown(e, index, item.id)}
-            ref={(el) => (itemRefs.current[index] = el)}
-            className={`w-full flex items-center p-3 rounded-md text-left hover:bg-[#003C73] transition-colors duration-150
+        <SortableList
+          items={listItems}
+          onChange={handleReorder}
+          disabled={!isEditing}
+          renderItem={(item, index) =>
+            isEditing ? (
+              <div className="flex items-center space-x-2 p-2 bg-[#003C73] rounded-md">
+                <input
+                  value={item.label}
+                  onChange={(e) => handleLabelChange(item.id, e.target.value)}
+                  className="flex-grow bg-transparent border-b border-gray-300 focus:outline-none"
+                  aria-label={`rename-${item.id}`}
+                />
+                <label className="flex items-center text-xs">
+                  <input
+                    type="checkbox"
+                    checked={!item.hidden}
+                    onChange={() => handleToggleHidden(item.id)}
+                  />
+                  <span className="ml-1">Show</span>
+                </label>
+              </div>
+            ) : (
+              <button
+                key={item.id}
+                onClick={() => onSelectTab(item.id)}
+                tabIndex={0}
+                onKeyDown={(e) => handleKeyDown(e, index, item.id)}
+                ref={(el) => (itemRefs.current[index] = el)}
+                className={`w-full flex items-center p-3 rounded-md text-left hover:bg-[#003C73] transition-colors duration-150
                         ${isOpen ? 'justify-start space-x-3' : 'justify-center'}
-                        ${activeTabId === item.id ? 'bg-[#00A3E0] text-white' : 'text-gray-300 hover:text-white'}`}
-            title={item.label}
-            aria-label={item.label}
-            role="menuitem"
-            aria-current={activeTabId === item.id ? 'page' : undefined}
-          >
-            <item.icon title={item.label} className="w-5 h-5 flex-shrink-0" />
-            {isOpen && <span className="truncate">{item.label}</span>}
-          </button>
-        ))}
+                        ${activeTabId === item.id ? 'bg-[#00A3E0] text-white border-l-4 border-yellow-300' : 'text-gray-300 hover:text-white'}`}
+                title={item.label}
+                aria-label={item.label}
+                role="menuitem"
+                aria-current={activeTabId === item.id ? 'page' : undefined}
+              >
+                <item.icon title={item.label} className="w-5 h-5 flex-shrink-0" />
+                {isOpen && <span className="truncate">{item.label}</span>}
+              </button>
+            )
+          }
+        />
       </nav>
     </div>
   );

--- a/components/SortableList.tsx
+++ b/components/SortableList.tsx
@@ -1,0 +1,57 @@
+import React, { useState } from 'react';
+
+interface SortableListProps<T> {
+  items: T[];
+  onChange: (items: T[]) => void;
+  renderItem: (item: T, index: number) => React.ReactNode;
+  disabled?: boolean;
+}
+
+function SortableList<T extends { id: string }>({
+  items,
+  onChange,
+  renderItem,
+  disabled = false,
+}: SortableListProps<T>) {
+  const [dragIndex, setDragIndex] = useState<number | null>(null);
+
+  const handleDragStart = (index: number) => () => {
+    if (disabled) return;
+    setDragIndex(index);
+  };
+
+  const handleDragOver = (index: number) => (e: React.DragEvent) => {
+    if (disabled) return;
+    e.preventDefault();
+    if (dragIndex === null || dragIndex === index) return;
+    const updated = [...items];
+    const [moved] = updated.splice(dragIndex, 1);
+    updated.splice(index, 0, moved);
+    setDragIndex(index);
+    onChange(updated);
+  };
+
+  const handleDragEnd = () => {
+    if (disabled) return;
+    setDragIndex(null);
+  };
+
+  return (
+    <div>
+      {items.map((item, index) => (
+        <div
+          key={(item as any).id || index}
+          data-testid="sortable-item"
+          draggable={!disabled}
+          onDragStart={handleDragStart(index)}
+          onDragOver={handleDragOver(index)}
+          onDragEnd={handleDragEnd}
+        >
+          {renderItem(item, index)}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default SortableList;

--- a/tests/Sidebar.test.tsx
+++ b/tests/Sidebar.test.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent, screen, cleanup } from './setup.ts';
+import Sidebar from '../components/Sidebar.tsx';
+import { MenuItem, DataItem } from '../types.ts';
+
+const DummyIcon: React.FC<React.SVGProps<SVGSVGElement>> = () => (
+  <svg data-testid="icon" />
+);
+
+const baseItems: MenuItem<DataItem>[] = [
+  { id: 'a', label: 'Item A', icon: DummyIcon },
+  { id: 'b', label: 'Item B', icon: DummyIcon },
+  { id: 'c', label: 'Item C', icon: DummyIcon },
+];
+
+describe('Sidebar', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+  afterEach(() => {
+    cleanup();
+  });
+
+  test('supports keyboard navigation', () => {
+    const handleSelect = vi.fn();
+    render(
+      <Sidebar
+        menuItems={baseItems}
+        activeTabId={null}
+        onSelectTab={handleSelect}
+        isOpen={true}
+      />
+    );
+
+    const buttons = screen.getAllByRole('menuitem');
+    buttons[0].focus();
+    fireEvent.keyDown(buttons[0], { key: 'ArrowDown' });
+    expect(document.activeElement).toBe(buttons[1]);
+    fireEvent.keyDown(buttons[1], { key: 'ArrowUp' });
+    expect(document.activeElement).toBe(buttons[0]);
+    fireEvent.keyDown(buttons[0], { key: 'Enter' });
+    expect(handleSelect).toHaveBeenCalledWith('a');
+  });
+
+  test('allows drag reorder', () => {
+    render(
+      <Sidebar
+        menuItems={baseItems}
+        activeTabId={null}
+        onSelectTab={() => {}}
+        isOpen={true}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /edit/i }));
+    const items = screen.getAllByTestId('sortable-item');
+    fireEvent.dragStart(items[0]);
+    fireEvent.dragOver(items[1]);
+    fireEvent.dragEnd(items[0]);
+    fireEvent.click(screen.getByRole('button', { name: /done/i }));
+    const buttons = screen.getAllByRole('menuitem');
+    expect(buttons[0]).toHaveTextContent('Item B');
+    const stored = JSON.parse(localStorage.getItem('sidebar-menu')!);
+    expect(stored[0].id).toBe('b');
+  });
+
+  test('edit mode can rename and hide items', () => {
+    render(
+      <Sidebar
+        menuItems={baseItems}
+        activeTabId={null}
+        onSelectTab={() => {}}
+        isOpen={true}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /edit/i }));
+    const nameInput = screen.getByDisplayValue('Item A');
+    fireEvent.change(nameInput, { target: { value: 'Alpha' } });
+    const checkboxes = screen.getAllByRole('checkbox');
+    fireEvent.click(checkboxes[1]); // hide Item B
+    fireEvent.click(screen.getByRole('button', { name: /done/i }));
+
+    expect(screen.getByRole('menuitem', { name: 'Alpha' })).toBeInTheDocument();
+    expect(screen.queryByRole('menuitem', { name: 'Item B' })).toBeNull();
+    const stored = JSON.parse(localStorage.getItem('sidebar-menu')!);
+    expect(stored.find((i: any) => i.id === 'a').label).toBe('Alpha');
+    expect(stored.find((i: any) => i.id === 'b').hidden).toBe(true);
+  });
+});

--- a/types.ts
+++ b/types.ts
@@ -97,6 +97,7 @@ export interface MenuItem<T extends DataItem> {
   fields?: FieldConfig<T>[];
   dataKey?: keyof AppData;
   getRowClass?: (item: T) => string;
+  hidden?: boolean;
 }
 
 export interface AppData {


### PR DESCRIPTION
## Summary
- add SortableList and localStorage persistence for menu order
- allow editing menu items with rename and hide options
- cover sidebar keyboard nav, reordering, and edit mode in tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898ac4746a88331aef17cad91317e16