### PR TITLE
Add sortable quick actions in user dropdown

### DIFF
--- a/components/QuickActionsDropdown.tsx
+++ b/components/QuickActionsDropdown.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import { SortableList, useSortableList, useSortableItem } from '../utils/dnd.tsx';
+import { CSS } from '@dnd-kit/utilities';
+import MenuIcon from './icons/MenuIcon.tsx';
+import PlusIcon from './icons/PlusIcon.tsx';
+import PencilIcon from './icons/PencilIcon.tsx';
+import TrashIcon from './icons/TrashIcon.tsx';
+
+export interface QuickAction {
+  id: string;
+  label: string;
+  icon: React.ComponentType<React.SVGProps<SVGSVGElement>>;
+  enabled: boolean;
+}
+
+export const DEFAULT_QUICK_ACTIONS: QuickAction[] = [
+  { id: 'add', label: 'Adicionar', icon: PlusIcon, enabled: true },
+  { id: 'edit', label: 'Editar', icon: PencilIcon, enabled: true },
+  { id: 'delete', label: 'Excluir', icon: TrashIcon, enabled: false },
+];
+
+interface QuickActionsDropdownProps {
+  menuItemRefs: React.MutableRefObject<(HTMLInputElement | null)[]>;
+}
+
+const QuickActionsDropdown: React.FC<QuickActionsDropdownProps> = ({ menuItemRefs }) => {
+  return (
+    <SortableList items={DEFAULT_QUICK_ACTIONS}>
+      <QuickActionsContent menuItemRefs={menuItemRefs} />
+    </SortableList>
+  );
+};
+
+const QuickActionsContent: React.FC<QuickActionsDropdownProps> = ({ menuItemRefs }) => {
+  const { items, setItems } = useSortableList<QuickAction>();
+
+  const toggleAction = (id: string) => {
+    setItems(items.map((a) => (a.id === id ? { ...a, enabled: !a.enabled } : a)));
+  };
+
+  return (
+    <ul className="divide-y" role="menu">
+      {items.map((action, index) => (
+        <QuickActionRow
+          key={action.id}
+          action={action}
+          index={index}
+          onToggle={toggleAction}
+          menuItemRefs={menuItemRefs}
+        />
+      ))}
+    </ul>
+  );
+};
+
+interface QuickActionRowProps {
+  action: QuickAction;
+  index: number;
+  onToggle: (id: string) => void;
+  menuItemRefs: React.MutableRefObject<(HTMLInputElement | null)[]>;
+}
+
+const QuickActionRow: React.FC<QuickActionRowProps> = ({ action, index, onToggle, menuItemRefs }) => {
+  const { attributes, listeners, setNodeRef, transform, transition } = useSortableItem(action.id);
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+  const Icon = action.icon;
+
+  return (
+    <li
+      ref={setNodeRef}
+      style={style}
+      className="flex items-center justify-between px-4 py-2 bg-white"
+    >
+      <div className="flex items-center space-x-2">
+        <button
+          {...attributes}
+          {...listeners}
+          aria-label={`Reordenar ${action.label}`}
+          className="cursor-grab p-1 text-gray-400 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[#00A3E0]"
+        >
+          <MenuIcon className="w-4 h-4" />
+        </button>
+        <Icon
+          className={`w-5 h-5 sm:w-5 sm:h-5 ${
+            action.enabled ? 'text-gray-700' : 'text-gray-300'
+          }`}
+        />
+        <span className="text-sm">{action.label}</span>
+      </div>
+      <input
+        type="checkbox"
+        checked={action.enabled}
+        onChange={() => onToggle(action.id)}
+        ref={(el) => (menuItemRefs.current[index] = el)}
+        className="h-4 w-4"
+        aria-label={`Ativar ${action.label}`}
+      />
+    </li>
+  );
+};
+
+export default QuickActionsDropdown;

--- a/components/TopBar.tsx
+++ b/components/TopBar.tsx
@@ -4,6 +4,7 @@ import MenuIcon from './icons/MenuIcon.tsx';
 import UserCircleIcon from './icons/UserCircleIcon.tsx';
 import IdentificationIcon from './icons/IdentificationIcon.tsx';
 import ArrowLeftOnRectangleIcon from './icons/ArrowLeftOnRectangleIcon.tsx'; // Updated import
+import QuickActionsDropdown, { DEFAULT_QUICK_ACTIONS } from './QuickActionsDropdown.tsx';
 
 interface TopBarProps {
   userName: string | undefined; // userName can be undefined if currentUser is null
@@ -23,8 +24,9 @@ const TopBar: React.FC<TopBarProps> = ({
   onToggleUserDropdown,
 }) => {
   const dropdownRef = useRef<HTMLDivElement>(null);
-  const menuItemRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  const menuItemRefs = useRef<Array<HTMLElement | null>>([]);
   const [activeIndex, setActiveIndex] = useState(0);
+  const quickActionsCount = DEFAULT_QUICK_ACTIONS.length;
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
@@ -98,7 +100,7 @@ const TopBar: React.FC<TopBarProps> = ({
           {isUserDropdownOpen && (
             <div
               id="user-menu"
-              className="absolute right-0 mt-2 w-56 origin-top-right bg-white rounded-md shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none z-50"
+              className="absolute right-0 mt-2 w-64 max-w-[90vw] sm:w-56 origin-top-right bg-white rounded-md shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none z-50"
               role="menu"
               aria-orientation="vertical"
               aria-labelledby="user-menu-button"
@@ -106,26 +108,30 @@ const TopBar: React.FC<TopBarProps> = ({
               onKeyDown={handleKeyDown}
             >
               <div className="py-1" role="none">
+                <div className="border-b">
+                  <p className="px-4 py-2 text-xs font-semibold text-gray-500">Ações rápidas</p>
+                  <QuickActionsDropdown menuItemRefs={menuItemRefs} />
+                </div>
                 <button
-                  ref={(el) => (menuItemRefs.current[0] = el)}
+                  ref={(el) => (menuItemRefs.current[quickActionsCount] = el)}
                   onClick={() => {
                     onProfileClick();
                   }}
                   className="w-full text-left flex items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 hover:text-gray-900 focus:bg-gray-100 focus:text-gray-900 focus:outline-none"
                   role="menuitem"
-                  id="user-menu-item-0"
+                  id={`user-menu-item-${quickActionsCount}`}
                 >
                   <IdentificationIcon title="Perfil" className="w-5 h-5 mr-3 text-gray-500" />
                   Perfil
                 </button>
                 <button
-                  ref={(el) => (menuItemRefs.current[1] = el)}
+                  ref={(el) => (menuItemRefs.current[quickActionsCount + 1] = el)}
                   onClick={() => {
                     onLogoutClick();
                   }}
                   className="w-full text-left flex items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 hover:text-gray-900 focus:bg-gray-100 focus:text-gray-900 focus:outline-none"
                   role="menuitem"
-                  id="user-menu-item-1"
+                  id={`user-menu-item-${quickActionsCount + 1}`}
                 >
                   <ArrowLeftOnRectangleIcon title="Logout" className="w-5 h-5 mr-3 text-gray-500" />
                   Logout

--- a/tests/TopBar.test.tsx
+++ b/tests/TopBar.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen, fireEvent, waitFor } from './setup.ts';
+import userEvent from '@testing-library/user-event';
+import { test, expect } from 'vitest';
+import TopBar from '../components/TopBar.tsx';
+
+function setup() {
+  return render(
+    <TopBar
+      userName="Alice"
+      onToggleSidebar={() => {}}
+      onProfileClick={() => {}}
+      onLogoutClick={() => {}}
+      isUserDropdownOpen={true}
+      onToggleUserDropdown={() => {}}
+    />
+  );
+}
+
+test('keyboard navigation cycles through dropdown items', async () => {
+  setup();
+  const user = userEvent.setup();
+  const toggles = await screen.findAllByRole('checkbox');
+  await waitFor(() => expect(toggles[0]).toHaveFocus());
+  await user.keyboard('{ArrowDown}');
+  expect(toggles[1]).toHaveFocus();
+  await user.keyboard('{ArrowDown}{ArrowDown}');
+  const profileButton = screen.getByRole('menuitem', { name: /perfil/i });
+  expect(profileButton).toHaveFocus();
+});
+
+test('quick actions expose focusable drag handles', () => {
+  setup();
+  const handles = screen.getAllByLabelText(/Reordenar/);
+  handles[0].focus();
+  expect(handles[0]).toHaveFocus();
+});

--- a/utils/dnd.tsx
+++ b/utils/dnd.tsx
@@ -1,5 +1,5 @@
-import { DndContext, PointerSensor, closestCenter, useSensor, useSensors, DragEndEvent } from '@dnd-kit/core';
-import { SortableContext, verticalListSortingStrategy, useSortable, arrayMove } from '@dnd-kit/sortable';
+import { DndContext, PointerSensor, KeyboardSensor, closestCenter, useSensor, useSensors, DragEndEvent } from '@dnd-kit/core';
+import { SortableContext, verticalListSortingStrategy, useSortable, arrayMove, sortableKeyboardCoordinates } from '@dnd-kit/sortable';
 import React, { createContext, useContext, useState } from 'react';
 
 interface ItemWithId {
@@ -21,7 +21,10 @@ export function SortableList<T extends ItemWithId>({
   children: React.ReactNode;
 }) {
   const [items, setItems] = useState<T[]>(initialItems);
-  const sensors = useSensors(useSensor(PointerSensor));
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+  );
 
   const handleDragEnd = (event: DragEndEvent) => {
     const { active, over } = event;


### PR DESCRIPTION
## Summary
- expose quick action icons in user menu with drag handles and toggles
- support keyboard navigation through dropdown items
- test keyboard navigation and drag handle focus

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898ac4debb083318f78b87f71c20fbc