### PR TITLE
feat: make waterfall chart configurable

### DIFF
--- a/components/charts/WaterfallChart.tsx
+++ b/components/charts/WaterfallChart.tsx
@@ -1,5 +1,5 @@
 
-import React, { useMemo } from 'react';
+import React, { useMemo, useState, useEffect, useRef } from 'react';
 import {
     BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Label, Cell, LabelList
 } from 'recharts';
@@ -68,7 +68,7 @@ const processData = (data: WaterfallChartDataPoint[]) => {
     return processed;
 };
 
-const CustomTooltip = ({ active, payload, label }: any) => {
+const CustomTooltip = ({ active, payload, label, formatter }: any) => {
     if (active && payload && payload.length) {
         const data = payload[0].payload;
         return (
@@ -76,7 +76,7 @@ const CustomTooltip = ({ active, payload, label }: any) => {
                 <p className="font-semibold text-gray-700 mb-1">{label}</p>
                 <div className="text-sm" style={{ color: data.type === 'increase' ? '#4CAF50' : data.type === 'decrease' ? '#D9262E' : data.type === 'subtotal' ? '#FF9800' : '#00A3E0' }}>
                     {data.type === 'total' ? 'Total: ' : data.type === 'subtotal' ? 'Subtotal: ' : 'Variação: '}
-                    {currencyFormatter(data.value)}
+                    {formatter(data.value)}
                 </div>
             </div>
         );
@@ -85,13 +85,75 @@ const CustomTooltip = ({ active, payload, label }: any) => {
 };
 
 const WaterfallChart: React.FC<WaterfallChartProps> = ({ data, title, config }) => {
-    const processedData = useMemo(() => processData(data), [data]);
+    const [items, setItems] = useState<WaterfallChartDataPoint[]>(data);
+
+    useEffect(() => {
+        setItems(data);
+    }, [data]);
+
+    const dragIndex = useRef<number | null>(null);
+
+    const handleDragStart = (index: number) => {
+        dragIndex.current = index;
+    };
+
+    const handleDrop = (index: number) => {
+        if (dragIndex.current === null) return;
+        const updated = [...items];
+        const [moved] = updated.splice(dragIndex.current, 1);
+        updated.splice(index, 0, moved);
+        dragIndex.current = null;
+        setItems(updated);
+    };
+
+    const handleDropSubtotal = () => {
+        if (dragIndex.current === null) return;
+        const updated = items.map((item, idx) => idx === dragIndex.current ? { ...item, subtotal: true } : item);
+        dragIndex.current = null;
+        setItems(updated);
+    };
+
+    const handleLabelChange = (index: number, label: string) => {
+        setItems(prev => prev.map((item, idx) => idx === index ? { ...item, category: label } : item));
+    };
+
+    const processedData = useMemo(() => processData(items), [items]);
 
     const { value: valueConfig } = config;
+    const valueFormatter = valueConfig?.formatter ?? currencyFormatter;
 
     return (
         <div className="bg-white p-6 rounded-lg shadow-lg h-96 flex flex-col">
             <h3 className="text-lg font-semibold text-gray-800 mb-4 text-center">{title}</h3>
+            <ul className="mb-4">
+                {items.map((item, index) => (
+                    <li
+                        key={index}
+                        data-testid={`wf-item-${index}`}
+                        draggable
+                        onDragStart={() => handleDragStart(index)}
+                        onDragOver={e => e.preventDefault()}
+                        onDrop={() => handleDrop(index)}
+                        className="flex items-center gap-2 mb-2"
+                    >
+                        <input
+                            aria-label={`label-input-${index}`}
+                            value={item.category}
+                            onChange={e => handleLabelChange(index, e.target.value)}
+                            className="border border-gray-300 rounded p-1 flex-1"
+                        />
+                        <span className="text-xs text-gray-500">{valueFormatter(item.value)}</span>
+                    </li>
+                ))}
+            </ul>
+            <div
+                data-testid="subtotal-drop"
+                onDragOver={e => e.preventDefault()}
+                onDrop={handleDropSubtotal}
+                className="border border-dashed border-gray-400 text-center text-xs text-gray-500 p-2 mb-4"
+            >
+                Arraste para subtotal
+            </div>
             <div className="flex-grow">
                 <ResponsiveContainer width="100%" height="100%">
                     <BarChart
@@ -100,10 +162,10 @@ const WaterfallChart: React.FC<WaterfallChartProps> = ({ data, title, config }) 
                     >
                         <CartesianGrid strokeDasharray="3 3" vertical={false} />
                         <XAxis dataKey="category" stroke="#6B7280" tick={{ fontSize: 12 }} />
-                        <YAxis stroke="#6B7280" tickFormatter={currencyFormatter} tick={{ fontSize: 12 }}>
+                        <YAxis stroke="#6B7280" tickFormatter={valueFormatter} tick={{ fontSize: 12 }}>
                             <Label value={valueConfig?.label} angle={-90} offset={-5} position="insideLeft" style={{ textAnchor: 'middle' }} fill="#6B7280" fontSize={14} />
                         </YAxis>
-                        <Tooltip content={<CustomTooltip />} cursor={{ fill: 'rgba(229, 231, 235, 0.5)' }} />
+                        <Tooltip content={<CustomTooltip formatter={valueFormatter} />} cursor={{ fill: 'rgba(229, 231, 235, 0.5)' }} />
                         <Bar dataKey="range" radius={[2, 2, 0, 0]}>
                             {processedData.map((entry, index) => {
                                 let color = '#000';

--- a/tests/charts/WaterfallChart.test.tsx
+++ b/tests/charts/WaterfallChart.test.tsx
@@ -1,0 +1,58 @@
+import userEvent from '@testing-library/user-event';
+import { render, screen, fireEvent } from '../setup.ts';
+import { test, expect, beforeAll, afterEach } from 'vitest';
+import WaterfallChart from '../../components/charts/WaterfallChart.tsx';
+import { DynamicChartConfig } from '../../types.ts';
+import { cleanup } from '../setup.ts';
+
+type WFPoint = { category: string; value: number };
+
+const sampleData: WFPoint[] = [
+  { category: 'A', value: 10 },
+  { category: 'B', value: 20 },
+  { category: 'C', value: 30 },
+];
+
+const config: DynamicChartConfig = {
+  sourceDataKey: 'waterfallData',
+  chartType: 'Waterfall',
+  value: { dataKey: 'value', label: 'Valor' }
+};
+
+beforeAll(() => {
+  // jsdom doesn't implement ResizeObserver which is required by Recharts' ResponsiveContainer
+  // @ts-ignore
+  global.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+test('reorders bars when dragged', () => {
+  const { container } = render(<WaterfallChart data={sampleData} title="Test" config={config} />);
+  const items = container.querySelectorAll('[data-testid^="wf-item-"]');
+  fireEvent.dragStart(items[0]);
+  fireEvent.dragOver(items[2]);
+  fireEvent.drop(items[2]);
+  const inputs = screen.getAllByLabelText(/label-input-/);
+  expect(inputs[2]).toHaveValue('A');
+});
+
+test('label edits persist after reorder', async () => {
+  const user = userEvent.setup();
+  const { container } = render(<WaterfallChart data={sampleData} title="Test" config={config} />);
+  const firstInput = screen.getByLabelText('label-input-0');
+  await user.clear(firstInput);
+  await user.type(firstInput, 'Alpha');
+  const items = container.querySelectorAll('[data-testid^="wf-item-"]');
+  fireEvent.dragStart(items[0]);
+  fireEvent.dragOver(items[2]);
+  fireEvent.drop(items[2]);
+  const inputs = screen.getAllByLabelText(/label-input-/);
+  expect(inputs[2]).toHaveValue('Alpha');
+});

--- a/types.ts
+++ b/types.ts
@@ -153,6 +153,7 @@ export interface ChartWell {
     dataKey: keyof SalesData | 'category' | 'value' | 'stage' | 'name' | 'size' | 'colorMetric';
     label?: string;
     aggregation?: AggregationType;
+    formatter?: (value: number) => string;
 }
 
 export interface DynamicChartConfig {


### PR DESCRIPTION
## Summary
- enable drag-and-drop reordering and subtotal conversion in Waterfall chart
- allow editing bar labels and custom value formatting
- add unit tests for Waterfall chart reordering and label persistence

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898ae732cac83318074de4550d38de5