### PR TITLE
feat: reorderable pie chart slices

### DIFF
--- a/components/charts/PieChart.tsx
+++ b/components/charts/PieChart.tsx
@@ -1,7 +1,23 @@
 
 import React, { useState } from 'react';
-import { PieChart as RechartsPieChart, Pie, Cell, Tooltip, Legend, ResponsiveContainer, Sector } from 'recharts';
+import {
+    PieChart as RechartsPieChart,
+    Pie,
+    Cell,
+    Tooltip,
+    Legend,
+    ResponsiveContainer,
+    Sector,
+} from 'recharts';
 import { DynamicChartConfig } from '../../types.ts';
+
+interface PieSlice {
+    id: string;
+    name: string;
+    value: number;
+    color: string;
+    showLabel: boolean;
+}
 
 interface PieChartProps {
     data: { name: string; value: number }[];
@@ -10,22 +26,18 @@ interface PieChartProps {
     showLabels?: boolean;
 }
 
-const COLORS = ['#00A3E0', '#005A9C', '#64B5F6', '#2196F3', '#FFCA28', '#FF7043', '#4CAF50', '#F44336'];
+const COLORS = [
+    '#00A3E0',
+    '#005A9C',
+    '#64B5F6',
+    '#2196F3',
+    '#FFCA28',
+    '#FF7043',
+    '#4CAF50',
+    '#F44336',
+];
 
 const RADIAN = Math.PI / 180;
-const renderCustomizedLabel = ({ cx, cy, midAngle, innerRadius, outerRadius, percent }: any) => {
-    const radius = innerRadius + (outerRadius - innerRadius) * 0.5;
-    const x = cx + radius * Math.cos(-midAngle * RADIAN);
-    const y = cy + radius * Math.sin(-midAngle * RADIAN);
-
-    if (percent < 0.05) return null; // Don't render label for small slices
-
-    return (
-        <text x={x} y={y} fill="white" textAnchor="middle" dominantBaseline="central" className="text-xs font-semibold">
-            {`${(percent * 100).toFixed(0)}%`}
-        </text>
-    );
-};
 
 const renderActiveShape = ({
     cx,
@@ -47,13 +59,16 @@ const renderActiveShape = ({
     />
 );
 
-const PieChart: React.FC<PieChartProps> = ({
-    data,
-    title,
-    config,
-    showLabels = false,
-}) => {
+const PieChart: React.FC<PieChartProps> = ({ data, title, config, showLabels = false }) => {
     const [activeIndex, setActiveIndex] = useState<number | null>(null);
+    const [slices, setSlices] = useState<PieSlice[]>(
+        data.map((d, index) => ({
+            id: `${index}-${d.name}`,
+            ...d,
+            color: COLORS[index % COLORS.length],
+            showLabel: true,
+        }))
+    );
 
     const onPieEnter = (_: any, index: number) => {
         setActiveIndex(index);
@@ -63,44 +78,157 @@ const PieChart: React.FC<PieChartProps> = ({
         setActiveIndex(null);
     };
 
+    const handleColorChange = (i: number, color: string) => {
+        setSlices((prev) => {
+            const next = [...prev];
+            next[i].color = color;
+            return next;
+        });
+    };
+
+    const handleToggleLabel = (i: number) => {
+        setSlices((prev) => {
+            const next = [...prev];
+            next[i].showLabel = !next[i].showLabel;
+            return next;
+        });
+    };
+
+    const moveSlice = (from: number, to: number) => {
+        setSlices((prev) => {
+            const copy = [...prev];
+            const [removed] = copy.splice(from, 1);
+            copy.splice(to, 0, removed);
+            return copy;
+        });
+    };
+
+    const handleDragStart = (e: React.DragEvent<HTMLLIElement>, index: number) => {
+        e.dataTransfer.setData('text/plain', index.toString());
+    };
+
+    const handleDrop = (e: React.DragEvent<HTMLLIElement>, index: number) => {
+        const from = Number(e.dataTransfer.getData('text/plain'));
+        if (!Number.isNaN(from) && from !== index) {
+            moveSlice(from, index);
+        }
+    };
+
+    const handleKeyDown = (e: React.KeyboardEvent<HTMLLIElement>, index: number) => {
+        if (e.key === 'ArrowUp' && index > 0) {
+            e.preventDefault();
+            moveSlice(index, index - 1);
+        } else if (e.key === 'ArrowDown' && index < slices.length - 1) {
+            e.preventDefault();
+            moveSlice(index, index + 1);
+        }
+    };
+
+    const renderCustomizedLabel = ({
+        cx,
+        cy,
+        midAngle,
+        innerRadius,
+        outerRadius,
+        percent,
+        index,
+    }: any) => {
+        if (!slices[index].showLabel || percent < 0.05) return null;
+        const radius = innerRadius + (outerRadius - innerRadius) * 0.5;
+        const x = cx + radius * Math.cos(-midAngle * RADIAN);
+        const y = cy + radius * Math.sin(-midAngle * RADIAN);
+        return (
+            <text
+                x={x}
+                y={y}
+                fill="white"
+                textAnchor="middle"
+                dominantBaseline="central"
+                className="text-xs font-semibold"
+            >
+                {`${(percent * 100).toFixed(0)}%`}
+            </text>
+        );
+    };
+
     return (
-        <div className="bg-white p-6 rounded-lg shadow-lg h-96 flex flex-col">
+        <div className="bg-white p-6 rounded-lg shadow-lg flex flex-col" style={{ height: '24rem' }}>
             <h3 className="text-lg font-semibold text-gray-800 mb-4 text-center">{title}</h3>
-            <div className="flex-grow">
-                <ResponsiveContainer width="100%" height="100%">
-                    <RechartsPieChart>
-                        <Pie
-                            data={data}
-                            dataKey="value"
-                            nameKey="name"
-                            cx="50%"
-                            cy="50%"
-                            innerRadius={'60%'}
-                            outerRadius={'80%'}
-                            fill="#8884d8"
-                            paddingAngle={2}
-                            labelLine={false}
-                            label={showLabels ? renderCustomizedLabel : undefined}
-                            activeIndex={activeIndex ?? undefined}
-                            activeShape={renderActiveShape}
-                            onMouseEnter={onPieEnter}
-                            onMouseLeave={onPieLeave}
+            <div className="flex-grow flex">
+                <div className="flex-grow">
+                    <ResponsiveContainer width="100%" height="100%">
+                        <RechartsPieChart>
+                            <Pie
+                                data={slices}
+                                dataKey="value"
+                                nameKey="name"
+                                cx="50%"
+                                cy="50%"
+                                innerRadius={'60%'}
+                                outerRadius={'80%'}
+                                fill="#8884d8"
+                                paddingAngle={2}
+                                labelLine={false}
+                                label={showLabels ? renderCustomizedLabel : undefined}
+                                activeIndex={activeIndex ?? undefined}
+                                activeShape={renderActiveShape}
+                                onMouseEnter={onPieEnter}
+                                onMouseLeave={onPieLeave}
+                            >
+                                {slices.map((entry, index) => (
+                                    <Cell
+                                        key={entry.id}
+                                        fill={entry.color}
+                                        stroke={entry.color}
+                                    />
+                                ))}
+                            </Pie>
+                            <Tooltip
+                                formatter={(value, name) => [
+                                    `${(value as number).toLocaleString('pt-BR', {
+                                        style: 'currency',
+                                        currency: 'BRL',
+                                    })}`,
+                                    name,
+                                ]}
+                                contentStyle={{
+                                    backgroundColor: 'rgba(255, 255, 255, 0.9)',
+                                    border: '1px solid #E5E7EB',
+                                    borderRadius: '0.5rem',
+                                }}
+                            />
+                            <Legend wrapperStyle={{ fontSize: '12px' }} />
+                        </RechartsPieChart>
+                    </ResponsiveContainer>
+                </div>
+                <ul aria-label="slice controls" className="ml-4 w-48">
+                    {slices.map((slice, index) => (
+                        <li
+                            key={slice.id}
+                            draggable
+                            onDragStart={(e) => handleDragStart(e, index)}
+                            onDragOver={(e) => e.preventDefault()}
+                            onDrop={(e) => handleDrop(e, index)}
+                            tabIndex={0}
+                            onKeyDown={(e) => handleKeyDown(e, index)}
+                            className="flex items-center gap-2 mb-2"
                         >
-                            {data.map((entry, index) => (
-                                <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} stroke={COLORS[index % COLORS.length]} />
-                            ))}
-                        </Pie>
-                        <Tooltip
-                          formatter={(value, name) => [`${(value as number).toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' })}`, name]}
-                          contentStyle={{
-                            backgroundColor: 'rgba(255, 255, 255, 0.9)',
-                            border: '1px solid #E5E7EB',
-                            borderRadius: '0.5rem',
-                          }}
-                        />
-                        <Legend wrapperStyle={{fontSize: "12px"}} />
-                    </RechartsPieChart>
-                </ResponsiveContainer>
+                            <span className="flex-1">{slice.name}</span>
+                            <input
+                                aria-label="color"
+                                type="color"
+                                value={slice.color}
+                                onChange={(e) => handleColorChange(index, e.target.value)}
+                            />
+                            <input
+                                aria-label="toggle label"
+                                type="checkbox"
+                                checked={slice.showLabel}
+                                onChange={() => handleToggleLabel(index)}
+                            />
+                        </li>
+                    ))}
+                </ul>
             </div>
         </div>
     );

--- a/tests/charts/PieChart.test.tsx
+++ b/tests/charts/PieChart.test.tsx
@@ -1,0 +1,52 @@
+import { fireEvent } from '@testing-library/react';
+import { beforeAll, expect, test } from 'vitest';
+import { render, screen } from '../setup.ts';
+import PieChart from '../../components/charts/PieChart.tsx';
+
+beforeAll(() => {
+  class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+  (global as any).ResizeObserver = ResizeObserver;
+  Object.defineProperty(HTMLElement.prototype, 'clientWidth', {
+    configurable: true,
+    value: 400,
+  });
+  Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+    configurable: true,
+    value: 400,
+  });
+});
+
+const data = [
+  { name: 'A', value: 30 },
+  { name: 'B', value: 70 }
+];
+
+const config = { sourceDataKey: 'detailedData', chartType: 'Pie' } as const;
+
+test('allows dragging slices to reorder', () => {
+  render(<PieChart data={data} title="Test" config={config} showLabels />);
+  const items = screen.getAllByRole('listitem');
+  const first = items[0];
+  const second = items[1];
+  const dataTransfer = {
+    data: {} as Record<string, string>,
+    setData(key: string, value: string) { this.data[key] = value; },
+    getData(key: string) { return this.data[key]; }
+  };
+  fireEvent.dragStart(second, { dataTransfer });
+  fireEvent.dragOver(first, { dataTransfer });
+  fireEvent.drop(first, { dataTransfer });
+  const reordered = screen.getAllByRole('listitem');
+  expect(reordered[0]).toHaveTextContent('B');
+});
+
+test('updates slice color through color input', () => {
+  render(<PieChart data={data} title="Test" config={config} showLabels />);
+  const inputs = screen.getAllByLabelText('color');
+  fireEvent.input(inputs[0], { target: { value: '#000000' } });
+  expect(inputs[0]).toHaveValue('#000000');
+});


### PR DESCRIPTION
## Summary
- enable drag and keyboard slice reordering in PieChart
- add slice color editing and label visibility toggles
- test slice drag and color update behaviors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898ae6f5d648331ac739b29042cba42