### PR TITLE
feat: add editable and sortable funnel chart

### DIFF
--- a/components/charts/FunnelChart.tsx
+++ b/components/charts/FunnelChart.tsx
@@ -1,5 +1,4 @@
-
-import React from 'react';
+import React, { useState } from 'react';
 import { FunnelChart as RechartsFunnelChart, Funnel, Tooltip, LabelList, ResponsiveContainer } from 'recharts';
 import { DynamicChartConfig } from '../../types.ts';
 
@@ -11,11 +10,11 @@ interface FunnelChartProps {
 
 const formatValue = (value: number) => value.toLocaleString('pt-BR');
 
-const CustomTooltip = ({ active, payload, data }: { active?: boolean, payload?: any[], data: any[] }) => {
+const CustomTooltip = ({ active, payload, data }: { active?: boolean; payload?: any[]; data: any[] }) => {
     if (active && payload && payload.length) {
         const currentPayload = payload[0].payload;
         const { name, value } = currentPayload;
-        const currentIndex = data.findIndex(item => item.name === name);
+        const currentIndex = data.findIndex((item) => item.name === name);
 
         let conversionRate: number | null = null;
         if (currentIndex > 0) {
@@ -28,9 +27,7 @@ const CustomTooltip = ({ active, payload, data }: { active?: boolean, payload?: 
                 <p className="font-semibold text-gray-700 mb-2">{name}</p>
                 <p className="text-sm text-blue-600">Valor: {formatValue(value)}</p>
                 {conversionRate !== null && (
-                    <p className="text-sm text-green-600 mt-1">
-                        Conversão: {conversionRate.toFixed(1)}% do estágio anterior
-                    </p>
+                    <p className="text-sm text-green-600 mt-1">Conversão: {conversionRate.toFixed(1)}% do estágio anterior</p>
                 )}
             </div>
         );
@@ -41,32 +38,89 @@ const CustomTooltip = ({ active, payload, data }: { active?: boolean, payload?: 
 const FunnelChart: React.FC<FunnelChartProps> = ({ data, title, config }) => {
     const { category, value } = config;
 
-    const chartData = data.map(item => ({
+    const initialData = data.map((item, index) => ({
         // @ts-ignore
         name: item[category?.dataKey],
         // @ts-ignore
         value: item[value?.dataKey],
-        // @ts-ignore
-        fill: '#00A3E0' // Default color, can be customized
+        id: index.toString(),
+        fill: '#00A3E0'
     }));
+
+    const [stages, setStages] = useState(initialData);
+    const [dragIndex, setDragIndex] = useState<number | null>(null);
+
+    const handleDragStart = (index: number) => () => {
+        setDragIndex(index);
+    };
+
+    const handleDragOver = (index: number) => (e: React.DragEvent<HTMLDivElement>) => {
+        e.preventDefault();
+    };
+
+    const handleDrop = (index: number) => () => {
+        if (dragIndex === null) return;
+        setStages((prev) => {
+            const updated = [...prev];
+            const [removed] = updated.splice(dragIndex, 1);
+            updated.splice(index, 0, removed);
+            return updated;
+        });
+        setDragIndex(null);
+    };
+
+    const handleNameChange = (index: number) => (e: React.ChangeEvent<HTMLInputElement>) => {
+        const newName = e.target.value;
+        setStages((prev) => prev.map((stage, i) => (i === index ? { ...stage, name: newName } : stage)));
+    };
+
+    const handleValueChange = (index: number) => (e: React.ChangeEvent<HTMLInputElement>) => {
+        const newValue = Number(e.target.value);
+        setStages((prev) =>
+            prev.map((stage, i) => (i === index ? { ...stage, value: isNaN(newValue) ? 0 : newValue } : stage))
+        );
+    };
 
     return (
         <div className="bg-white p-6 rounded-lg shadow-lg h-96 flex flex-col">
             <h3 className="text-lg font-semibold text-gray-800 mb-4 text-center">{title}</h3>
+            <div className="mb-4 space-y-2">
+                {stages.map((stage, index) => (
+                    <div
+                        key={stage.id}
+                        data-testid="stage-item"
+                        draggable
+                        onDragStart={handleDragStart(index)}
+                        onDragOver={handleDragOver(index)}
+                        onDrop={handleDrop(index)}
+                        className="flex items-center space-x-2"
+                    >
+                        <input
+                            data-testid="stage-name"
+                            value={stage.name}
+                            onChange={handleNameChange(index)}
+                            className="border p-1 rounded flex-1"
+                        />
+                        <input
+                            data-testid="stage-value"
+                            type="number"
+                            value={stage.value}
+                            onChange={handleValueChange(index)}
+                            className="border p-1 rounded w-24"
+                        />
+                    </div>
+                ))}
+            </div>
             <div className="flex-grow">
                 <ResponsiveContainer width="100%" height="100%">
                     <RechartsFunnelChart>
-                        <Tooltip content={<CustomTooltip data={chartData} />} />
-                        <Funnel
-                            dataKey="value"
-                            data={chartData}
-                            isAnimationActive
-                        >
-                            <LabelList 
-                                position="center" 
-                                fill="#fff" 
-                                stroke="none" 
-                                dataKey="name" 
+                        <Tooltip content={<CustomTooltip data={stages} />} />
+                        <Funnel dataKey="value" data={stages} isAnimationActive>
+                            <LabelList
+                                position="center"
+                                fill="#fff"
+                                stroke="none"
+                                dataKey="name"
                                 className="text-xs font-semibold"
                             />
                         </Funnel>
@@ -78,3 +132,4 @@ const FunnelChart: React.FC<FunnelChartProps> = ({ data, title, config }) => {
 };
 
 export default FunnelChart;
+

--- a/tests/charts/FunnelChart.test.tsx
+++ b/tests/charts/FunnelChart.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen, fireEvent } from '../setup.ts';
+import userEvent from '@testing-library/user-event';
+import { test, expect } from 'vitest';
+import FunnelChart from '../../components/charts/FunnelChart.tsx';
+import { DynamicChartConfig } from '../../types.ts';
+
+class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+// @ts-ignore
+global.ResizeObserver = ResizeObserver;
+
+const config: DynamicChartConfig = {
+  sourceDataKey: 'funnelData',
+  chartType: 'Funnel',
+  category: { dataKey: 'name' },
+  value: { dataKey: 'value' },
+};
+
+test('dragging stages reorders them', () => {
+  const data = [
+    { name: 'Stage 1', value: 100 },
+    { name: 'Stage 2', value: 80 },
+    { name: 'Stage 3', value: 60 },
+  ];
+  render(<FunnelChart data={data} title="Funnel" config={config} />);
+
+  const items = screen.getAllByTestId('stage-item');
+  fireEvent.dragStart(items[0]);
+  fireEvent.dragOver(items[2]);
+  fireEvent.drop(items[2]);
+
+  const names = screen
+    .getAllByTestId('stage-name')
+    .map((input) => (input as HTMLInputElement).value);
+  expect(names).toEqual(['Stage 2', 'Stage 3', 'Stage 1']);
+});
+
+test('inline editing updates stage labels and values', async () => {
+  const data = [
+    { name: 'Stage 1', value: 100 },
+    { name: 'Stage 2', value: 80 },
+  ];
+  render(<FunnelChart data={data} title="Funnel" config={config} />);
+
+  const user = userEvent.setup();
+  const nameInput = screen.getAllByTestId('stage-name')[0] as HTMLInputElement;
+  const valueInput = screen.getAllByTestId('stage-value')[0] as HTMLInputElement;
+
+  await user.clear(nameInput);
+  await user.type(nameInput, 'Updated');
+  await user.clear(valueInput);
+  await user.type(valueInput, '123');
+
+  expect(nameInput.value).toBe('Updated');
+  expect(valueInput.value).toBe('123');
+});
+


### PR DESCRIPTION
## Summary
- enable drag-and-drop reordering and inline editing in `FunnelChart`
- test funnel stage edits and reordering

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898ae69d5b083319f5c6c126db37e16