### PR TITLE
feat: enable heatmap selection and color editing

### DIFF
--- a/components/charts/HeatmapChart.tsx
+++ b/components/charts/HeatmapChart.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo, useState } from 'react';
 import { SalesData, HeatmapConfig as HeatmapConfigType, AggregationType } from '../../types.ts';
+import useEditable from '../../hooks/useEditable.ts';
 
 interface HeatmapChartProps {
     data: SalesData[];
@@ -33,11 +34,18 @@ const formatValue = (value: number, label: string) => {
         return value.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL', notation: 'compact' });
     }
     return value.toLocaleString('pt-BR');
-}
+};
 
 const HeatmapChart: React.FC<HeatmapChartProps> = ({ data, title, config }) => {
     const { x: xConfig, y: yConfig, value: valConfig } = config;
     const [tooltip, setTooltip] = useState<TooltipState | null>(null);
+
+    const { isEditing, startEdit, stopEdit } = useEditable(false);
+    const [startColor, setStartColor] = useState('#C7E4F7');
+    const [endColor, setEndColor] = useState('#005A9C');
+
+    const [selectedCells, setSelectedCells] = useState<Set<string>>(new Set());
+    const [dragStart, setDragStart] = useState<{ x: number; y: number } | null>(null);
 
     const { gridData, xLabels, yLabels, valueRange } = useMemo(() => {
         if (!data || data.length === 0) return { gridData: new Map(), xLabels: [], yLabels: [], valueRange: [0, 0] };
@@ -48,10 +56,10 @@ const HeatmapChart: React.FC<HeatmapChartProps> = ({ data, title, config }) => {
         const valAgg = valConfig.aggregation || 'SUM';
 
         const allX = Array.from(new Set(data.map(d => String(d[xKey] ?? ''))));
-         // Special sort for months
+        // Special sort for months
         const monthOrder = ['Jan', 'Fev', 'Mar', 'Abr', 'Mai', 'Jun', 'Jul', 'Ago', 'Set', 'Out', 'Nov', 'Dez'];
         if (allX.every(x => monthOrder.includes(x))) {
-            allX.sort((a,b) => monthOrder.indexOf(a) - monthOrder.indexOf(b));
+            allX.sort((a, b) => monthOrder.indexOf(a) - monthOrder.indexOf(b));
         } else {
             allX.sort();
         }
@@ -85,20 +93,27 @@ const HeatmapChart: React.FC<HeatmapChartProps> = ({ data, title, config }) => {
         return { gridData, xLabels: allX, yLabels: allY, valueRange: [minVal, maxVal] };
     }, [data, xConfig, yConfig, valConfig]);
 
+    const parseHex = (hex: string) => {
+        const shorthand = /^#?([a-f\d])([a-f\d])([a-f\d])$/i;
+        hex = hex.replace(shorthand, (_m, r, g, b) => r + r + g + g + b + b);
+        const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+        return result
+            ? { r: parseInt(result[1], 16), g: parseInt(result[2], 16), b: parseInt(result[3], 16) }
+            : { r: 0, g: 0, b: 0 };
+    };
+
     const getColor = (value: number) => {
         const [min, max] = valueRange;
-        
-        // Handle no data case
+
         if (value === undefined || (min === 0 && max === 0 && value === 0)) return '#f0f0f0';
 
-        // From light blue (low/negative) to dark blue (high profit)
         const ratio = max === min ? 0.5 : (value - min) / (max - min);
-        const startColor = { r: 199, g: 228, b: 247 }; // #C7E4F7 lighter blue
-        const endColor = { r: 0, g: 90, b: 156 };     // #005A9C darker blue
+        const start = parseHex(startColor);
+        const end = parseHex(endColor);
 
-        const r = Math.round(startColor.r + ratio * (endColor.r - startColor.r));
-        const g = Math.round(startColor.g + ratio * (endColor.g - startColor.g));
-        const b = Math.round(startColor.b + ratio * (endColor.b - startColor.b));
+        const r = Math.round(start.r + ratio * (end.r - start.r));
+        const g = Math.round(start.g + ratio * (end.g - start.g));
+        const b = Math.round(start.b + ratio * (end.b - start.b));
         return `rgb(${r}, ${g}, ${b})`;
     };
 
@@ -106,19 +121,52 @@ const HeatmapChart: React.FC<HeatmapChartProps> = ({ data, title, config }) => {
         () => ({
             background: `linear-gradient(to right, ${getColor(valueRange[0])}, ${getColor(valueRange[1])})`
         }),
-        [valueRange]
+        [valueRange, startColor, endColor]
     );
 
-    const handleMouseEnter = (xVal: string, yVal: string, e: React.MouseEvent) => {
-        const value = gridData.get(`${yVal}|${xVal}`);
-        if (value === undefined) return;
+    const updateSelection = (xIndex: number, yIndex: number) => {
+        if (!dragStart) return;
+        const x1 = Math.min(dragStart.x, xIndex);
+        const x2 = Math.max(dragStart.x, xIndex);
+        const y1 = Math.min(dragStart.y, yIndex);
+        const y2 = Math.max(dragStart.y, yIndex);
+        const newSet = new Set<string>();
+        for (let yi = y1; yi <= y2; yi++) {
+            for (let xi = x1; xi <= x2; xi++) {
+                const xv = xLabels[xi];
+                const yv = yLabels[yi];
+                newSet.add(`${yv}|${xv}`);
+            }
+        }
+        setSelectedCells(newSet);
+    };
 
-        const content = `
+    const handleCellMouseEnter = (
+        xVal: string,
+        yVal: string,
+        xIndex: number,
+        yIndex: number,
+        e: React.MouseEvent
+    ) => {
+        const value = gridData.get(`${yVal}|${xVal}`);
+        if (value !== undefined) {
+            const content = `
             <div class="font-semibold text-base">${yConfig.label}: ${yVal}</div>
             <div class="text-sm">${xConfig.label}: ${xVal}</div>
             <div class="text-sm mt-1">${valConfig.label}: <span class="font-bold">${formatValue(value, valConfig.label || '')}</span></div>
         `;
-        setTooltip({ content, x: e.clientX, y: e.clientY });
+            setTooltip({ content, x: e.clientX, y: e.clientY });
+        }
+        if (dragStart) {
+            updateSelection(xIndex, yIndex);
+        }
+    };
+
+    const handleMouseDown = (xIndex: number, yIndex: number) => {
+        setDragStart({ x: xIndex, y: yIndex });
+        const xv = xLabels[xIndex];
+        const yv = yLabels[yIndex];
+        setSelectedCells(new Set([`${yv}|${xv}`]));
     };
 
     const handleMouseLeave = () => setTooltip(null);
@@ -127,10 +175,45 @@ const HeatmapChart: React.FC<HeatmapChartProps> = ({ data, title, config }) => {
             setTooltip({ ...tooltip, x: e.clientX, y: e.clientY });
         }
     };
+    const handleMouseUp = () => setDragStart(null);
 
     return (
-        <div className="bg-white p-6 rounded-lg shadow-lg h-96 flex flex-col" onMouseMove={handleMouseMove}>
-            <h3 className="text-lg font-semibold text-gray-800 mb-4 text-center">{title}</h3>
+        <div
+            className="bg-white p-6 rounded-lg shadow-lg h-96 flex flex-col"
+            onMouseMove={handleMouseMove}
+            onMouseUp={handleMouseUp}
+        >
+            <div className="flex items-center justify-between mb-4">
+                <h3 className="text-lg font-semibold text-gray-800 text-center flex-1">{title}</h3>
+                <button
+                    onClick={isEditing ? stopEdit : startEdit}
+                    className="ml-2 px-2 py-1 text-xs bg-gray-100 hover:bg-gray-200 rounded"
+                >
+                    {isEditing ? 'Done' : 'Edit Colors'}
+                </button>
+            </div>
+            {isEditing && (
+                <div className="flex gap-4 mb-2 text-xs">
+                    <label className="flex items-center gap-1">
+                        Start
+                        <input
+                            type="color"
+                            aria-label="start color"
+                            value={startColor}
+                            onChange={(e) => setStartColor(e.target.value)}
+                        />
+                    </label>
+                    <label className="flex items-center gap-1">
+                        End
+                        <input
+                            type="color"
+                            aria-label="end color"
+                            value={endColor}
+                            onChange={(e) => setEndColor(e.target.value)}
+                        />
+                    </label>
+                </div>
+            )}
             {tooltip && (
                 <div
                     style={{ position: 'fixed', top: tooltip.y + 15, left: tooltip.x + 15, pointerEvents: 'none', zIndex: 1000 }}
@@ -142,25 +225,38 @@ const HeatmapChart: React.FC<HeatmapChartProps> = ({ data, title, config }) => {
                 <table className="w-full border-collapse">
                     <thead>
                         <tr>
-                            <th className="p-2 border border-gray-200 bg-gray-50 sticky top-0 left-0 z-10">{yConfig.label} / {xConfig.label}</th>
+                            <th className="p-2 border border-gray-200 bg-gray-50 sticky top-0 left-0 z-10">
+                                {yConfig.label} / {xConfig.label}
+                            </th>
                             {xLabels.map(xVal => (
-                                <th key={xVal} className="p-2 border border-gray-200 bg-gray-50 sticky top-0 font-semibold">{xVal}</th>
+                                <th key={xVal} className="p-2 border border-gray-200 bg-gray-50 sticky top-0 font-semibold">
+                                    {xVal}
+                                </th>
                             ))}
                         </tr>
                     </thead>
                     <tbody>
-                        {yLabels.map(yVal => (
+                        {yLabels.map((yVal, yi) => (
                             <tr key={yVal}>
-                                <th className="p-2 border border-gray-200 bg-gray-50 sticky left-0 font-semibold text-left">{yVal}</th>
-                                {xLabels.map(xVal => {
+                                <th className="p-2 border border-gray-200 bg-gray-50 sticky left-0 font-semibold text-left">
+                                    {yVal}
+                                </th>
+                                {xLabels.map((xVal, xi) => {
                                     const value = gridData.get(`${yVal}|${xVal}`);
                                     const color = value !== undefined ? getColor(value) : '#f0f0f0';
+                                    const cellKey = `${yVal}|${xVal}`;
+                                    const isSelected = selectedCells.has(cellKey);
                                     return (
                                         <td
                                             key={xVal}
-                                            className="p-2 border border-white hover:border-gray-800 transition-all cursor-pointer"
+                                            data-testid={`cell-${yi}-${xi}`}
+                                            data-selected={isSelected ? 'true' : 'false'}
+                                            className={`p-2 border border-white hover:border-gray-800 transition-all cursor-pointer ${
+                                                isSelected ? 'ring-2 ring-black' : ''
+                                            }`}
                                             style={{ backgroundColor: color }}
-                                            onMouseEnter={(e) => handleMouseEnter(xVal, yVal, e)}
+                                            onMouseEnter={(e) => handleCellMouseEnter(xVal, yVal, xi, yi, e)}
+                                            onMouseDown={() => handleMouseDown(xi, yi)}
                                             onMouseLeave={handleMouseLeave}
                                         >
                                             <div className="w-full h-full min-w-[30px] min-h-[30px]"></div>
@@ -182,3 +278,4 @@ const HeatmapChart: React.FC<HeatmapChartProps> = ({ data, title, config }) => {
 };
 
 export default HeatmapChart;
+

--- a/tests/charts/HeatmapChart.test.tsx
+++ b/tests/charts/HeatmapChart.test.tsx
@@ -1,0 +1,52 @@
+import { fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render, screen, cleanup } from '../setup.ts';
+import { test, expect, afterEach } from 'vitest';
+import HeatmapChart from '../../components/charts/HeatmapChart.tsx';
+import { SalesData, HeatmapConfig } from '../../types.ts';
+
+const data: SalesData[] = [
+  { id: '1', mes: 'Jan', regiao: 'North', categoria: '', vendas: 10, lucro: 0, clientes: 0 },
+  { id: '2', mes: 'Feb', regiao: 'North', categoria: '', vendas: 20, lucro: 0, clientes: 0 },
+  { id: '3', mes: 'Jan', regiao: 'South', categoria: '', vendas: 30, lucro: 0, clientes: 0 },
+  { id: '4', mes: 'Feb', regiao: 'South', categoria: '', vendas: 40, lucro: 0, clientes: 0 }
+];
+
+const config: HeatmapConfig = {
+  sourceDataKey: 'detailedData',
+  x: { dataKey: 'mes', label: 'Month' },
+  y: { dataKey: 'regiao', label: 'Region' },
+  value: { dataKey: 'vendas', label: 'Sales', aggregation: 'SUM' }
+};
+
+afterEach(() => cleanup());
+
+test('allows drag selecting a range of cells', () => {
+  render(<HeatmapChart data={data} title="Heatmap" config={config} />);
+
+  const startCell = screen.getByTestId('cell-0-0');
+  const endCell = screen.getByTestId('cell-1-1');
+
+  fireEvent.mouseDown(startCell);
+  fireEvent.mouseEnter(endCell);
+  fireEvent.mouseUp(endCell);
+
+  expect(screen.getByTestId('cell-0-0')).toHaveAttribute('data-selected', 'true');
+  expect(screen.getByTestId('cell-0-1')).toHaveAttribute('data-selected', 'true');
+  expect(screen.getByTestId('cell-1-0')).toHaveAttribute('data-selected', 'true');
+  expect(screen.getByTestId('cell-1-1')).toHaveAttribute('data-selected', 'true');
+});
+
+test('updates colors when editing color scale', async () => {
+  render(<HeatmapChart data={data} title="Heatmap" config={config} />);
+  const user = userEvent.setup();
+
+  await user.click(screen.getByRole('button', { name: /edit colors/i }));
+  const startInput = screen.getByLabelText(/start color/i);
+
+  fireEvent.change(startInput, { target: { value: '#ff0000' } });
+
+  const cell = screen.getByTestId('cell-0-1');
+  expect(cell).toHaveStyle({ backgroundColor: 'rgb(255, 0, 0)' });
+});
+


### PR DESCRIPTION
## Summary
- add drag selection logic to highlight a range of heatmap cells
- expose color scale editing via `useEditable` with interactive color inputs
- cover heatmap selection and color update behavior with tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898ae6aeef88331acfb43119499058a