### PR TITLE
feat: enable treemap node editing

### DIFF
--- a/components/charts/ColorMetricEditor.tsx
+++ b/components/charts/ColorMetricEditor.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { TreemapNode } from './TreemapChart.tsx';
+
+interface ColorMetricEditorProps {
+    formula: string;
+    onChange: (formula: string) => void;
+}
+
+// Simple editor that allows users to provide a formula used to calculate
+// the color metric of treemap nodes. The formula can reference "size" and
+// "colorMetric" fields of a node.
+const ColorMetricEditor: React.FC<ColorMetricEditorProps> = ({ formula, onChange }) => {
+    return (
+        <div className="flex flex-col gap-2">
+            <label htmlFor="color-metric-formula" className="text-sm font-medium text-gray-700">
+                Color Metric Formula
+            </label>
+            <input
+                id="color-metric-formula"
+                value={formula}
+                onChange={(e) => onChange(e.target.value)}
+                className="border rounded px-2 py-1"
+            />
+        </div>
+    );
+};
+
+export default ColorMetricEditor;
+
+// Utility to evaluate a color metric based on a formula string.
+// This is intentionally simple and intended for controlled input from
+// trusted users.
+export const evaluateColorMetric = (node: TreemapNode, formula: string): number => {
+    try {
+        // eslint-disable-next-line no-new-func
+        const fn = new Function('size', 'colorMetric', `return ${formula};`);
+        return Number(fn(node.size, node.colorMetric));
+    } catch {
+        return node.colorMetric;
+    }
+};

--- a/tests/charts/TreemapChart.test.tsx
+++ b/tests/charts/TreemapChart.test.tsx
@@ -1,0 +1,41 @@
+import { describe, test, expect } from 'vitest';
+import { moveNode, updateMetrics, TreemapNode } from '../../components/charts/TreemapChart.tsx';
+
+const createSampleTree = (): TreemapNode[] => [
+    {
+        name: 'A',
+        size: 0,
+        colorMetric: 0,
+        children: [{ name: 'leaf', size: 10, colorMetric: 10 }],
+    },
+    { name: 'B', size: 0, colorMetric: 0 },
+];
+
+describe('Treemap editing', () => {
+    test('moveNode moves leaf to new parent and updates metrics', () => {
+        const data = createSampleTree();
+        updateMetrics(data); // establish initial parent metrics
+
+        moveNode(data, 'leaf', 'B');
+        updateMetrics(data);
+
+        const a = data.find((n) => n.name === 'A')!;
+        const b = data.find((n) => n.name === 'B')!;
+
+        expect(a.children?.length).toBe(0);
+        expect(a.size).toBe(0);
+        expect(b.children?.[0].name).toBe('leaf');
+        expect(b.size).toBe(10);
+        expect(b.colorMetric).toBe(10);
+    });
+
+    test('updateMetrics applies custom formula', () => {
+        const data: TreemapNode[] = [
+            { name: 'A', size: 2, colorMetric: 0 },
+            { name: 'B', size: 3, colorMetric: 0 },
+        ];
+        updateMetrics(data, (n) => n.size * 5);
+        expect(data[0].colorMetric).toBe(10);
+        expect(data[1].colorMetric).toBe(15);
+    });
+});


### PR DESCRIPTION
## Summary
- add utilities to move treemap nodes and recalc metrics for hierarchical editing
- introduce color metric editor for custom formula input
- test node moving and custom metric calculations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898ae71b28c8331a127366c7b5ad77b