### PR TITLE
feat: enable drag handles and inline editing for KPI cards

### DIFF
--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -487,13 +487,19 @@ const Dashboard: React.FC = () => {
             onLayoutChange={handleLayoutChange}
             margin={[16,16]}
             className={isEditing ? 'dashboard-editing bg-gray-50 border-2 border-dashed' : ''}
+            draggableHandle=".drag-handle"
         >
             {dashboardConfig.widgets.map(widget => {
                 const Component = componentMap[widget.component];
                 const props = getWidgetProps(widget);
                 return (
                     <div key={widget.id} className={isEditing ? 'border border-dashed relative' : 'relative'}>
-                        {isEditing && <button onClick={() => setEditingWidget(widget)} className="absolute top-1 right-1 bg-white p-1 rounded shadow" aria-label="Editar widget">✏️</button>}
+                        {isEditing && widget.component !== 'KpiCard' && (
+                            <span className="drag-handle absolute top-1 left-1 cursor-move">⋮⋮</span>
+                        )}
+                        {isEditing && (
+                            <button onClick={() => setEditingWidget(widget)} className="absolute top-1 right-1 bg-white p-1 rounded shadow" aria-label="Editar widget">✏️</button>
+                        )}
                         <Component {...props} />
                     </div>
                 );

--- a/components/charts/KpiCard.tsx
+++ b/components/charts/KpiCard.tsx
@@ -1,5 +1,5 @@
 
-import React from 'react';
+import React, { useState } from 'react';
 
 interface KpiCardProps {
   title: string;
@@ -29,10 +29,43 @@ const KpiCard: React.FC<Partial<KpiCardProps>> = ({
   isLoading = false,
   error,
 }) => {
-  const changeColor = changeType === 'positive' ? 'text-green-500' : changeType === 'negative' ? 'text-red-500' : 'text-gray-500';
+  const changeColor =
+    changeType === 'positive'
+      ? 'text-green-500'
+      : changeType === 'negative'
+      ? 'text-red-500'
+      : 'text-gray-500';
+
+  const [titleState, setTitleState] = useState(String(title));
+  const [valueState, setValueState] = useState(String(value));
+  const [editingTitle, setEditingTitle] = useState(false);
+  const [editingValue, setEditingValue] = useState(false);
+  const [titleError, setTitleError] = useState('');
+  const [valueError, setValueError] = useState('');
+
+  const commitTitle = () => {
+    if (titleState.trim() === '') {
+      setTitleError('Title is required');
+      setTitleState(String(title));
+    } else {
+      setTitleError('');
+    }
+    setEditingTitle(false);
+  };
+
+  const commitValue = () => {
+    if (valueState.trim() === '') {
+      setValueError('Value is required');
+      setValueState(String(value));
+    } else {
+      setValueError('');
+    }
+    setEditingValue(false);
+  };
 
   return (
-    <div className="bg-white p-6 rounded-lg shadow-lg">
+    <div className="bg-white p-6 rounded-lg shadow-lg relative">
+      <div className="drag-handle absolute top-1 left-1 cursor-move" aria-label="drag handle">⋮⋮</div>
       {isLoading ? (
         <div className="flex items-center justify-center h-full">
           <svg
@@ -60,8 +93,46 @@ const KpiCard: React.FC<Partial<KpiCardProps>> = ({
         <p className="text-sm text-red-500 text-center">{error}</p>
       ) : (
         <>
-          <h3 className="text-sm font-medium text-gray-500 truncate">{title}</h3>
-          <p className="mt-1 text-3xl font-semibold text-gray-900">{value}</p>
+          {editingTitle ? (
+            <input
+              className="text-sm font-medium text-gray-500 truncate border-b border-gray-300"
+              value={titleState}
+              onChange={(e) => setTitleState(e.target.value)}
+              onBlur={commitTitle}
+              onKeyDown={(e) => e.key === 'Enter' && commitTitle()}
+              autoFocus
+            />
+          ) : (
+            <h3
+              className="text-sm font-medium text-gray-500 truncate"
+              onClick={() => setEditingTitle(true)}
+            >
+              {titleState}
+            </h3>
+          )}
+          {titleError && (
+            <p className="text-xs text-red-500 mt-1">{titleError}</p>
+          )}
+          {editingValue ? (
+            <input
+              className="mt-1 text-3xl font-semibold text-gray-900 border-b border-gray-300"
+              value={valueState}
+              onChange={(e) => setValueState(e.target.value)}
+              onBlur={commitValue}
+              onKeyDown={(e) => e.key === 'Enter' && commitValue()}
+              autoFocus
+            />
+          ) : (
+            <p
+              className="mt-1 text-3xl font-semibold text-gray-900"
+              onClick={() => setEditingValue(true)}
+            >
+              {valueState}
+            </p>
+          )}
+          {valueError && (
+            <p className="text-xs text-red-500 mt-1">{valueError}</p>
+          )}
           {change && (
             <p className="mt-2 text-sm text-gray-500">
               <span className={`font-semibold ${changeColor}`}>{change}</span>

--- a/tests/charts/KpiCard.test.tsx
+++ b/tests/charts/KpiCard.test.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import userEvent from '@testing-library/user-event';
+import { render, screen } from '../setup.ts';
+import { test, expect } from 'vitest';
+import ReactGridLayout from 'react-grid-layout';
+import KpiCard from '../../components/charts/KpiCard.tsx';
+
+const TestGrid = () => {
+  const [layout, setLayout] = React.useState([
+    { i: 'a', x: 0, y: 0, w: 1, h: 1 },
+    { i: 'b', x: 1, y: 0, w: 1, h: 1 }
+  ]);
+  return (
+    <div>
+      <button onClick={() => setLayout([
+        { i: 'a', x: 1, y: 0, w: 1, h: 1 },
+        { i: 'b', x: 0, y: 0, w: 1, h: 1 }
+      ])}>swap</button>
+      <ReactGridLayout
+        layout={layout}
+        cols={2}
+        rowHeight={30}
+        width={300}
+        draggableHandle=".drag-handle"
+      >
+        <div key="a" data-testid="card-a"><KpiCard title="A" value="1" /></div>
+        <div key="b" data-testid="card-b"><KpiCard title="B" value="2" /></div>
+      </ReactGridLayout>
+    </div>
+  );
+};
+
+test('drag handle exists and reorders layout when swapped', async () => {
+  const user = userEvent.setup();
+  const { container } = render(<TestGrid />);
+  const handle = container.querySelector('.drag-handle');
+  expect(handle).not.toBeNull();
+  const cardA = screen.getByTestId('card-a');
+  const before = cardA.style.transform;
+  await user.click(screen.getByRole('button', { name: /swap/i }));
+  expect(cardA.style.transform).not.toBe(before);
+});
+
+test('edits title and value inline with validation', async () => {
+  const user = userEvent.setup();
+  render(<KpiCard />);
+  // edit title
+  await user.click(screen.getByText('Vendas Totais'));
+  const titleInput = screen.getByDisplayValue('Vendas Totais');
+  await user.clear(titleInput);
+  await user.type(titleInput, 'New Title');
+  await user.keyboard('{Enter}');
+  expect(screen.getByText('New Title')).toBeInTheDocument();
+
+  // edit value
+  await user.click(screen.getByText('R$1.2M'));
+  const valueInput = screen.getByDisplayValue('R$1.2M');
+  await user.clear(valueInput);
+  await user.type(valueInput, 'R$2M');
+  await user.keyboard('{Enter}');
+  expect(screen.getByText('R$2M')).toBeInTheDocument();
+
+  // validation
+  await user.click(screen.getByText('R$2M'));
+  const invalid = screen.getByDisplayValue('R$2M');
+  await user.clear(invalid);
+  await user.keyboard('{Enter}');
+  expect(screen.getByText('Value is required')).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- add drag handles and inline editing with validation to KPI cards
- enable draggable handles in dashboard layout
- test KpiCard reordering and in-place edits

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898ae6c4a1083318ec771a7856917d0