### PR TITLE
feat: add draggable scatter points and trendline editing

### DIFF
--- a/components/charts/ScatterChart.tsx
+++ b/components/charts/ScatterChart.tsx
@@ -14,6 +14,7 @@ import {
     Line
 } from 'recharts';
 import { DynamicChartConfig } from '../../types.ts';
+import useEditable from '../../hooks/useEditable.ts';
 import PlayIcon from '../icons/PlayIcon.tsx';
 import PauseIcon from '../icons/PauseIcon.tsx';
 
@@ -24,6 +25,7 @@ interface ScatterChartProps {
     title: string;
     config: DynamicChartConfig;
     showTrendline?: boolean;
+    onDataChange?: (newData: any[]) => void;
 }
 
 const CustomTooltip = ({ active, payload, config }: any) => {
@@ -48,28 +50,33 @@ const CustomTooltip = ({ active, payload, config }: any) => {
     return null;
 };
 
-const ScatterChart: React.FC<ScatterChartProps> = ({ data, title, config, showTrendline = false }) => {
+const ScatterChart: React.FC<ScatterChartProps> = ({ data, title, config, showTrendline = false, onDataChange }) => {
     const { x, y, size, legend, playAxis, category } = config;
+    const { isEditing, startEdit, stopEdit, showTrendline: trendlineVisible, toggleTrendline } = useEditable(false, showTrendline);
     const [currentIndex, setCurrentIndex] = useState(0);
     const [isPlaying, setIsPlaying] = useState(false);
     const intervalRef = useRef<NodeJS.Timeout | null>(null);
 
+    const [chartData, setChartData] = useState(data);
+    useEffect(() => setChartData(data), [data]);
+    const chartDataWithIndex = useMemo(() => chartData.map((d, i) => ({ ...d, __index: i })), [chartData]);
+
     const playAxisValues = useMemo(() => {
-        if (!playAxis?.dataKey || !data) return [];
-        const uniqueValues = [...new Set(data.map(item => item[playAxis.dataKey]))];
+        if (!playAxis?.dataKey || !chartData) return [];
+        const uniqueValues = [...new Set(chartData.map(item => item[playAxis.dataKey]))];
         // Assuming a chronological sort for months, etc. Can be improved with date objects if needed.
         return uniqueValues.sort();
-    }, [data, playAxis]);
+    }, [chartData, playAxis]);
 
     const currentPlayAxisValue = playAxis ? playAxisValues[currentIndex] : null;
 
     const filteredData = useMemo(() => {
-        if (!playAxis || !currentPlayAxisValue) return data;
-        return data.filter(d => d[playAxis.dataKey] === currentPlayAxisValue);
-    }, [data, playAxis, currentPlayAxisValue]);
+        if (!playAxis || !currentPlayAxisValue) return chartDataWithIndex;
+        return chartDataWithIndex.filter(d => d[playAxis.dataKey] === currentPlayAxisValue);
+    }, [chartDataWithIndex, playAxis, currentPlayAxisValue]);
 
     const trendLineData = useMemo(() => {
-        if (!showTrendline || !x?.dataKey || !y?.dataKey || filteredData.length < 2) return [];
+        if (!trendlineVisible || !x?.dataKey || !y?.dataKey || filteredData.length < 2) return [];
         const n = filteredData.length;
         const sumX = filteredData.reduce((acc, cur) => acc + cur[x.dataKey], 0);
         const sumY = filteredData.reduce((acc, cur) => acc + cur[y.dataKey], 0);
@@ -86,7 +93,7 @@ const ScatterChart: React.FC<ScatterChartProps> = ({ data, title, config, showTr
             { [x.dataKey]: minX, trend: slope * minX + intercept },
             { [x.dataKey]: maxX, trend: slope * maxX + intercept }
         ];
-    }, [showTrendline, filteredData, x?.dataKey, y?.dataKey]);
+    }, [trendlineVisible, filteredData, x?.dataKey, y?.dataKey]);
 
     const series = useMemo(() => {
         if (!legend?.dataKey) {
@@ -100,6 +107,58 @@ const ScatterChart: React.FC<ScatterChartProps> = ({ data, title, config, showTr
         });
         return Object.entries(grouped).map(([name, data]) => ({ name, data }));
     }, [filteredData, legend, category]);
+
+    const snap = (val: number) => Math.round(val / 10) * 10;
+    const [dragInfo, setDragInfo] = useState<{
+        index: number;
+        startX: number;
+        startY: number;
+        origX: number;
+        origY: number;
+    } | null>(null);
+
+    const startDrag = (index: number, event: React.MouseEvent<SVGCircleElement, MouseEvent>) => {
+        const payload = chartData[index];
+        setDragInfo({
+            index,
+            startX: event.clientX,
+            startY: event.clientY,
+            origX: payload[x.dataKey],
+            origY: payload[y.dataKey]
+        });
+        event.preventDefault();
+    };
+
+    const handleMouseMove = (event: MouseEvent) => {
+        if (!dragInfo) return;
+        const dx = event.clientX - dragInfo.startX;
+        const dy = event.clientY - dragInfo.startY;
+        const newX = snap(dragInfo.origX + dx);
+        const newY = snap(dragInfo.origY + dy);
+        setChartData(prev => {
+            const updated = [...prev];
+            updated[dragInfo.index] = {
+                ...updated[dragInfo.index],
+                [x.dataKey]: newX,
+                [y.dataKey]: newY
+            };
+            onDataChange && onDataChange(updated);
+            return updated;
+        });
+    };
+
+    const endDrag = () => setDragInfo(null);
+
+    useEffect(() => {
+        if (dragInfo) {
+            window.addEventListener('mousemove', handleMouseMove);
+            window.addEventListener('mouseup', endDrag);
+        }
+        return () => {
+            window.removeEventListener('mousemove', handleMouseMove);
+            window.removeEventListener('mouseup', endDrag);
+        };
+    }, [dragInfo]);
 
     const stopPlaying = useCallback(() => {
         setIsPlaying(false);
@@ -144,9 +203,35 @@ const ScatterChart: React.FC<ScatterChartProps> = ({ data, title, config, showTr
 
     const bubbleSizeRange: [number, number] = [20, 500]; // min/max bubble size in pixels area
 
+    const renderPoint = (props: any) => {
+        const { cx, cy, payload, fill } = props;
+        return (
+            <circle
+                cx={cx}
+                cy={cy}
+                r={5}
+                fill={fill}
+                onMouseDown={(e) => startDrag(payload.__index, e)}
+                data-testid={`point-${payload.__index}`}
+            />
+        );
+    };
+
     return (
         <div className="bg-white p-6 rounded-lg shadow-lg h-[32rem] flex flex-col">
             <h3 className="text-lg font-semibold text-gray-800 mb-2 text-center">{title}</h3>
+            {isEditing ? (
+                <div className="flex justify-end gap-2 mb-2">
+                    <button data-testid="toggle-trendline" onClick={toggleTrendline} className="px-2 py-1 border rounded">
+                        {trendlineVisible ? 'Hide Trendline' : 'Show Trendline'}
+                    </button>
+                    <button data-testid="edit-toggle" onClick={stopEdit} className="px-2 py-1 border rounded">Done</button>
+                </div>
+            ) : (
+                <div className="flex justify-end mb-2">
+                    <button data-testid="edit-toggle" onClick={startEdit} className="px-2 py-1 border rounded">Edit</button>
+                </div>
+            )}
             {playAxis && (
                 <div className="flex items-center justify-center gap-4 mb-4 p-2 bg-gray-50 rounded-lg">
                     <button onClick={() => isPlaying ? stopPlaying() : startPlaying()} className="p-2 rounded-full hover:bg-gray-200 transition-colors">
@@ -179,12 +264,20 @@ const ScatterChart: React.FC<ScatterChartProps> = ({ data, title, config, showTr
                         <Tooltip content={<CustomTooltip config={config} />} cursor={{ strokeDasharray: '3 3' }} />
                         <Legend wrapperStyle={{fontSize: "12px", paddingTop: "40px"}} />
 
-                        {showTrendline && trendLineData.length > 0 && (
-                            <Line type="linear" dataKey="trend" data={trendLineData} stroke="#8884d8" dot={false} />
+                        {trendlineVisible && trendLineData.length > 0 && (
+                            <g data-testid="trendline">
+                                <Line type="linear" dataKey="trend" data={trendLineData} stroke="#8884d8" dot={false} />
+                            </g>
                         )}
 
                         {series.map((s, index) => (
-                            <Scatter key={s.name} name={s.name} data={s.data} fill={lineColors[index % lineColors.length]} shape="circle" />
+                            <Scatter
+                                key={s.name}
+                                name={s.name}
+                                data={s.data}
+                                fill={lineColors[index % lineColors.length]}
+                                shape={renderPoint}
+                            />
                         ))}
                     </RechartsScatterChart>
                 </ResponsiveContainer>

--- a/context/EditContext.tsx
+++ b/context/EditContext.tsx
@@ -3,8 +3,10 @@ import useEditable from '@/hooks/useEditable';
 
 interface EditContextValue {
   isEditing: boolean;
+  showTrendline: boolean;
   startEdit: () => void;
   stopEdit: () => void;
+  toggleTrendline: () => void;
 }
 
 const EditContext = createContext<EditContextValue | undefined>(undefined);

--- a/context/README.md
+++ b/context/README.md
@@ -5,9 +5,10 @@ Provides shared editing state across components.
 ## `useEditable`
 
 A hook that manages a boolean `isEditing` flag and exposes `startEdit` and `stopEdit` helpers.
+It also tracks a `showTrendline` flag that can be toggled when editing charts.
 
 ```tsx
-const { isEditing, startEdit, stopEdit } = useEditable();
+const { isEditing, startEdit, stopEdit, showTrendline, toggleTrendline } = useEditable();
 ```
 
 ## `EditProvider`
@@ -18,7 +19,7 @@ Wrap components with `EditProvider` to share editing state via context.
 import { EditProvider, useEdit } from '@/context/EditContext';
 
 function SomeComponent() {
-  const { isEditing, startEdit, stopEdit } = useEdit();
+  const { isEditing, startEdit, stopEdit, showTrendline, toggleTrendline } = useEdit();
   // ...
 }
 

--- a/hooks/useEditable.ts
+++ b/hooks/useEditable.ts
@@ -2,15 +2,22 @@ import { useState } from 'react';
 
 interface UseEditable {
   isEditing: boolean;
+  showTrendline: boolean;
   startEdit: () => void;
   stopEdit: () => void;
+  toggleTrendline: () => void;
 }
 
-export default function useEditable(initial: boolean = false): UseEditable {
+export default function useEditable(
+  initial: boolean = false,
+  initialTrendline: boolean = false
+): UseEditable {
   const [isEditing, setIsEditing] = useState(initial);
+  const [showTrendline, setShowTrendline] = useState(initialTrendline);
 
   const startEdit = () => setIsEditing(true);
   const stopEdit = () => setIsEditing(false);
+  const toggleTrendline = () => setShowTrendline((prev) => !prev);
 
-  return { isEditing, startEdit, stopEdit };
+  return { isEditing, startEdit, stopEdit, showTrendline, toggleTrendline };
 }

--- a/tests/charts/ScatterChart.test.tsx
+++ b/tests/charts/ScatterChart.test.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { describe, test, expect, vi, afterEach } from 'vitest';
+
+class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+(global as any).ResizeObserver = ResizeObserver;
+
+vi.mock('recharts', async () => {
+  const mod: any = await vi.importActual('recharts');
+  return {
+    ...mod,
+    ResponsiveContainer: ({ children }: any) => (
+      <div style={{ width: 500, height: 400 }}>
+        {React.cloneElement(children, { width: 500, height: 400 })}
+      </div>
+    ),
+  };
+});
+
+import { render, fireEvent, screen, cleanup } from '../setup';
+import ScatterChart from '../../components/charts/ScatterChart';
+import { DynamicChartConfig } from '../../types';
+
+describe('ScatterChart interactions', () => {
+  const config: DynamicChartConfig = {
+    sourceDataKey: 'detailedData',
+    chartType: 'Scatter',
+    x: { dataKey: 'x', label: 'X' },
+    y: { dataKey: 'y', label: 'Y' },
+  };
+
+  test('dragging a point updates coordinates with snapping', async () => {
+    const data = [
+      { x: 10, y: 20 },
+      { x: 20, y: 30 },
+    ];
+    const onChange = vi.fn();
+    render(
+      <ScatterChart data={data} title="Test" config={config} onDataChange={onChange} />
+    );
+    const point = await screen.findByTestId('point-0');
+    fireEvent.mouseDown(point, { clientX: 0, clientY: 0 });
+    fireEvent.mouseMove(window, { clientX: 7, clientY: 13 });
+    fireEvent.mouseUp(window);
+    const updated = onChange.mock.calls.at(-1)[0];
+    expect(updated[0].x).toBe(20);
+    expect(updated[0].y).toBe(30);
+  });
+
+  test('trendline can be toggled via editing', async () => {
+    const data = [
+      { x: 0, y: 0 },
+      { x: 10, y: 10 },
+    ];
+    render(
+      <ScatterChart data={data} title="Test" config={config} showTrendline={true} />
+    );
+    expect(await screen.findByTestId('trendline')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('edit-toggle'));
+    fireEvent.click(screen.getByTestId('toggle-trendline'));
+    expect(screen.queryByTestId('trendline')).not.toBeInTheDocument();
+  });
+});
+
+afterEach(() => {
+  cleanup();
+});


### PR DESCRIPTION
## Summary
- allow dragging scatter points with snapping and notify changes
- expose trendline editing via useEditable and context
- test scatter point dragging and trendline toggling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898ae708d288331bb352448a392777b