### PR TITLE
Allow all hosts for Vite dev server

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,6 +15,9 @@ export default defineConfig(({ mode }) => {
           '@': path.resolve(__dirname, '.'),
         }
       },
+      server: {
+        host: true,
+      },
       build: {
         sourcemap: true
       }


### PR DESCRIPTION
## Summary
- expose Vite dev server to all hosts by enabling `server.host`

## Testing
- `npm test` *(fails: ResizeObserver already declared)*

------
https://chatgpt.com/codex/tasks/task_e_6898d1b645148331a3af062d0d892f4d